### PR TITLE
Fix/haros ci

### DIFF
--- a/.github/workflows/haros.yml
+++ b/.github/workflows/haros.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           . /opt/ros/$ROS_DISTRO/setup.sh
           apt-get update && apt-get install -y python2 libmagic-dev
-          wget https://bootstrap.pypa.io/get-pip.py
+          wget https://bootstrap.pypa.io/2.7/get-pip.py
           python2 get-pip.py
           pip2 --version
           pip2 install haros

--- a/.github/workflows/haros.yml
+++ b/.github/workflows/haros.yml
@@ -1,10 +1,10 @@
 name: Haros Analysis
-on: push
-#on:
-#  push:
-#    branches: [ develop, master ]
-#  pull_request:
-#    branches: [ develop, master ]
+
+on:
+  push:
+    branches: [ develop, master ]
+  pull_request:
+    branches: [ develop, master ]
 
 jobs:
   haros:

--- a/.github/workflows/haros.yml
+++ b/.github/workflows/haros.yml
@@ -1,10 +1,10 @@
 name: Haros Analysis
-
-on:
-  push:
-    branches: [ develop, master ]
-  pull_request:
-    branches: [ develop, master ]
+on: push
+#on:
+#  push:
+#    branches: [ develop, master ]
+#  pull_request:
+#    branches: [ develop, master ]
 
 jobs:
   haros:


### PR DESCRIPTION
Quick fix for Haros. Basically, Haros runs on python2 and needs pip2 to be installed. On Ubuntu 20.04, pip2 needs to be installed via a weird installer which seems to have been tempered with today. Luckily, the maintainers provide a way to lock the version to install, which is what I did here.