### PR TITLE
Feat/swarinfo 195 refac ack handling

### DIFF
--- a/src/hiveboard_bridge/CMakeLists.txt
+++ b/src/hiveboard_bridge/CMakeLists.txt
@@ -31,6 +31,7 @@ set(LIB_ALIAS "SwarmUS::ROS::Hiveboard::Bridge")
 set(HIVEBOARD_BRIDGE_SOURCES
         src/TCPServer.cpp
         src/MessageHandler.cpp
+        src/MessageUtils.cpp
         src/ReceiveAction.cpp)
 
 add_library(${LIB_NAME} ${HIVEBOARD_BRIDGE_SOURCES})

--- a/src/hiveboard_bridge/cmake/propolis.cmake
+++ b/src/hiveboard_bridge/cmake/propolis.cmake
@@ -11,7 +11,7 @@ function(propolis_fetch_populate)
             ${PROJECT_NAME}_propolis
 
             GIT_REPOSITORY https://github.com/SwarmUS/Propolis
-            GIT_TAG        c0688a7e53d6f585d310ef355886fbaaf766b577
+            GIT_TAG        f185fce2039ae7f185f66389f2658a9622f3f80d
             GIT_PROGRESS   TRUE
     )
 

--- a/src/hiveboard_bridge/include/hiveboard_bridge/IMessageHandler.h
+++ b/src/hiveboard_bridge/include/hiveboard_bridge/IMessageHandler.h
@@ -16,14 +16,7 @@ typedef std::array<FunctionCallArgumentDTO,
                    FunctionCallRequestDTO::FUNCTION_CALL_ARGUMENTS_MAX_LENGTH>
     CallbackArgs;
 
-typedef struct {
-    uint32_t compoundSourceId;
-    uint32_t compoundDestinationId;
-    UserCallDestinationDTO moduleDestinationId;
-    uint32_t expectedResponseId;
-} CallbackContext;
-
-typedef std::function<void(CallbackArgs, int, CallbackContext)> CallbackFunction;
+typedef std::function<void(CallbackArgs, int)> CallbackFunction;
 
 typedef std::unordered_map<std::string, CallbackFunction> CallbackMap;
 

--- a/src/hiveboard_bridge/include/hiveboard_bridge/IMessageHandler.h
+++ b/src/hiveboard_bridge/include/hiveboard_bridge/IMessageHandler.h
@@ -34,9 +34,10 @@ class IMessageHandler {
     /**
      * Parse a message and execute the appropriate callback.
      * @param message the message to parse.
-     * @return True if the appropriate callback was found and executed, false otherwise
+     * @return A message containing the appropriate acknowlege (with appropriate errors if
+     * necessary)
      */
-    virtual bool handleMessage(MessageDTO message) = 0;
+    virtual MessageDTO handleMessage(MessageDTO message) = 0;
 
     /**
      * Register a callback

--- a/src/hiveboard_bridge/include/hiveboard_bridge/MessageHandler.h
+++ b/src/hiveboard_bridge/include/hiveboard_bridge/MessageHandler.h
@@ -2,13 +2,14 @@
 #define CATKIN_ROS_MESSAGEHANDLER_H
 
 #include "IMessageHandler.h"
+#include "hiveboard_bridge/MessageUtils.h"
 
 class MessageHandler : public IMessageHandler {
   public:
     MessageHandler();
     ~MessageHandler();
 
-    bool handleMessage(MessageDTO message) override;
+    MessageDTO handleMessage(MessageDTO message) override;
 
     bool registerCallback(std::string name, CallbackFunction callback) override;
 

--- a/src/hiveboard_bridge/include/hiveboard_bridge/MessageUtils.h
+++ b/src/hiveboard_bridge/include/hiveboard_bridge/MessageUtils.h
@@ -1,0 +1,18 @@
+#ifndef HIVEBOARD_BRIDGE_MESSAGEUTILS_H
+#define HIVEBOARD_BRIDGE_MESSAGEUTILS_H
+
+#include <hivemind-host/FunctionCallResponseDTO.h>
+#include <hivemind-host/MessageDTO.h>
+#include <hivemind-host/ResponseDTO.h>
+#include <hivemind-host/UserCallResponseDTO.h>
+
+namespace MessageUtils {
+    MessageDTO createResponseMessage(uint32_t responseId,
+                                     uint32_t msgSourceId,
+                                     uint32_t msgDestinationId,
+                                     UserCallDestinationDTO moduleDestination,
+                                     GenericResponseStatusDTO status,
+                                     std::string ackMessage);
+}
+
+#endif // HIVEBOARD_BRIDGE_MESSAGEUTILS_H

--- a/src/hiveboard_bridge/include/hiveboard_bridge/MessageUtils.h
+++ b/src/hiveboard_bridge/include/hiveboard_bridge/MessageUtils.h
@@ -6,13 +6,26 @@
 #include <hivemind-host/ResponseDTO.h>
 #include <hivemind-host/UserCallResponseDTO.h>
 
+/**
+ * Utilitary functions for message creation
+ */
 namespace MessageUtils {
+    /**
+     * Create a response message containing some parameters
+     * @param responseId Id of the request responded to
+     * @param msgSourceId Source of the response. Should correspond to the ID of this device.
+     * @param msgDestinationId Destination of the response.
+     * @param moduleDestination The module to which the response should be addressed.
+     * @param status The status of the processing of the message
+     * @param ackMessage A string containing some details.
+     * @return
+     */
     MessageDTO createResponseMessage(uint32_t responseId,
                                      uint32_t msgSourceId,
                                      uint32_t msgDestinationId,
                                      UserCallDestinationDTO moduleDestination,
                                      GenericResponseStatusDTO status,
                                      std::string ackMessage);
-}
+} // namespace MessageUtils
 
 #endif // HIVEBOARD_BRIDGE_MESSAGEUTILS_H

--- a/src/hiveboard_bridge/include/hiveboard_bridge/MessageUtils.h
+++ b/src/hiveboard_bridge/include/hiveboard_bridge/MessageUtils.h
@@ -23,7 +23,7 @@ namespace MessageUtils {
     MessageDTO createResponseMessage(uint32_t responseId,
                                      uint32_t msgSourceId,
                                      uint32_t msgDestinationId,
-                                     UserCallDestinationDTO moduleDestination,
+                                     UserCallTargetDTO moduleDestination,
                                      GenericResponseStatusDTO status,
                                      std::string ackMessage);
 } // namespace MessageUtils

--- a/src/hiveboard_bridge/include/hiveboard_bridge/ReceiveAction.h
+++ b/src/hiveboard_bridge/include/hiveboard_bridge/ReceiveAction.h
@@ -3,13 +3,16 @@
 
 #include "IMessageHandler.h"
 #include <hivemind-host/IHiveMindHostDeserializer.h>
+#include <hivemind-host/IHiveMindHostSerializer.h>
 
 /**
  * @brief A class that contains all the actions that must be done to fetch and process a message.
  */
 class ReceiveAction {
   public:
-    ReceiveAction(IHiveMindHostDeserializer& deserializer, IMessageHandler& messageHandler);
+    ReceiveAction(IHiveMindHostDeserializer& deserializer,
+                  IHiveMindHostSerializer& serializer,
+                  IMessageHandler& messageHandler);
 
     /**
      * Perform the actions.
@@ -18,6 +21,7 @@ class ReceiveAction {
 
   private:
     IHiveMindHostDeserializer& m_deserializer;
+    IHiveMindHostSerializer& m_serializer;
     IMessageHandler& m_messageHandler;
 };
 

--- a/src/hiveboard_bridge/src/MessageHandler.cpp
+++ b/src/hiveboard_bridge/src/MessageHandler.cpp
@@ -9,6 +9,7 @@ MessageDTO MessageHandler::handleMessage(MessageDTO message) {
     uint32_t msgSourceId = message.getSourceId();
     uint32_t msgDestinationId = message.getDestinationId();
     uint32_t requestId = 0;
+    UserCallTargetDTO sourceModule = UserCallTargetDTO::UNKNOWN;
 
     // Message
     auto request = message.getMessage();
@@ -23,6 +24,7 @@ MessageDTO MessageHandler::handleMessage(MessageDTO message) {
         if (std::holds_alternative<UserCallRequestDTO>(userCallRequest)) {
             std::variant<std::monostate, FunctionCallRequestDTO> functionCallRequest =
                 std::get<UserCallRequestDTO>(userCallRequest).getRequest();
+                sourceModule = std::get<UserCallRequestDTO>(userCallRequest).getSource();
 
             // FunctionCallRequest
             if (std::holds_alternative<FunctionCallRequestDTO>(functionCallRequest)) {
@@ -53,7 +55,7 @@ MessageDTO MessageHandler::handleMessage(MessageDTO message) {
     }
 
     return MessageUtils::createResponseMessage(requestId, msgDestinationId, msgSourceId,
-                                               UserCallDestinationDTO::BUZZ, responseStatus, "");
+                                               sourceModule, responseStatus, "");
 }
 
 bool MessageHandler::registerCallback(std::string name, CallbackFunction callback) {

--- a/src/hiveboard_bridge/src/MessageHandler.cpp
+++ b/src/hiveboard_bridge/src/MessageHandler.cpp
@@ -52,7 +52,7 @@ MessageDTO MessageHandler::handleMessage(MessageDTO message) {
         ROS_WARN("Message handling failed");
     }
 
-    return MessageUtils::createResponseMessage(requestId, msgSourceId, msgDestinationId,
+    return MessageUtils::createResponseMessage(requestId, msgDestinationId, msgSourceId,
                                                UserCallDestinationDTO::BUZZ, responseStatus, "");
 }
 

--- a/src/hiveboard_bridge/src/MessageHandler.cpp
+++ b/src/hiveboard_bridge/src/MessageHandler.cpp
@@ -24,7 +24,7 @@ MessageDTO MessageHandler::handleMessage(MessageDTO message) {
         if (std::holds_alternative<UserCallRequestDTO>(userCallRequest)) {
             std::variant<std::monostate, FunctionCallRequestDTO> functionCallRequest =
                 std::get<UserCallRequestDTO>(userCallRequest).getRequest();
-                sourceModule = std::get<UserCallRequestDTO>(userCallRequest).getSource();
+            sourceModule = std::get<UserCallRequestDTO>(userCallRequest).getSource();
 
             // FunctionCallRequest
             if (std::holds_alternative<FunctionCallRequestDTO>(functionCallRequest)) {

--- a/src/hiveboard_bridge/src/MessageHandler.cpp
+++ b/src/hiveboard_bridge/src/MessageHandler.cpp
@@ -37,14 +37,7 @@ MessageDTO MessageHandler::handleMessage(MessageDTO message) {
 
                 // Call the right callback
                 if (callback) {
-                    CallbackContext ctx;
-                    ctx.compoundSourceId = message.getSourceId();
-                    ctx.compoundDestinationId = message.getDestinationId();
-                    ctx.moduleDestinationId =
-                        std::get_if<UserCallRequestDTO>(&userCallRequest)->getDestination();
-                    ctx.expectedResponseId = std::get_if<RequestDTO>(&request)->getId();
-
-                    callback.value()(functionArgs, argsLength, ctx);
+                    callback.value()(functionArgs, argsLength);
                     responseStatus = GenericResponseStatusDTO::Ok;
                 } else {
                     responseStatus = GenericResponseStatusDTO::Unknown;

--- a/src/hiveboard_bridge/src/MessageUtils.cpp
+++ b/src/hiveboard_bridge/src/MessageUtils.cpp
@@ -1,0 +1,16 @@
+#include "hiveboard_bridge/MessageUtils.h"
+
+MessageDTO MessageUtils::createResponseMessage(uint32_t responseId,
+                                               uint32_t msgSourceId,
+                                               uint32_t msgDestinationId,
+                                               UserCallDestinationDTO moduleDestination,
+                                               GenericResponseStatusDTO status,
+                                               std::string ackMessage) {
+    FunctionCallResponseDTO functionCallResponse(status, ackMessage.c_str());
+    UserCallResponseDTO userCallResponse(moduleDestination, functionCallResponse);
+    ResponseDTO response(responseId, userCallResponse);
+    MessageDTO responseMessage(msgDestinationId, msgSourceId,
+                               response); // Swap source and destination for a response
+
+    return responseMessage;
+}

--- a/src/hiveboard_bridge/src/MessageUtils.cpp
+++ b/src/hiveboard_bridge/src/MessageUtils.cpp
@@ -9,8 +9,7 @@ MessageDTO MessageUtils::createResponseMessage(uint32_t responseId,
     FunctionCallResponseDTO functionCallResponse(status, ackMessage.c_str());
     UserCallResponseDTO userCallResponse(moduleDestination, functionCallResponse);
     ResponseDTO response(responseId, userCallResponse);
-    MessageDTO responseMessage(msgDestinationId, msgSourceId,
-                               response); // Swap source and destination for a response
+    MessageDTO responseMessage(msgSourceId, msgDestinationId, response);
 
     return responseMessage;
 }

--- a/src/hiveboard_bridge/src/MessageUtils.cpp
+++ b/src/hiveboard_bridge/src/MessageUtils.cpp
@@ -3,11 +3,11 @@
 MessageDTO MessageUtils::createResponseMessage(uint32_t responseId,
                                                uint32_t msgSourceId,
                                                uint32_t msgDestinationId,
-                                               UserCallDestinationDTO moduleDestination,
+                                               UserCallTargetDTO moduleDestination,
                                                GenericResponseStatusDTO status,
                                                std::string ackMessage) {
     FunctionCallResponseDTO functionCallResponse(status, ackMessage.c_str());
-    UserCallResponseDTO userCallResponse(moduleDestination, functionCallResponse);
+    UserCallResponseDTO userCallResponse(UserCallTargetDTO::HOST, moduleDestination, functionCallResponse);
     ResponseDTO response(responseId, userCallResponse);
     MessageDTO responseMessage(msgSourceId, msgDestinationId, response);
 

--- a/src/hiveboard_bridge/src/MessageUtils.cpp
+++ b/src/hiveboard_bridge/src/MessageUtils.cpp
@@ -7,7 +7,8 @@ MessageDTO MessageUtils::createResponseMessage(uint32_t responseId,
                                                GenericResponseStatusDTO status,
                                                std::string ackMessage) {
     FunctionCallResponseDTO functionCallResponse(status, ackMessage.c_str());
-    UserCallResponseDTO userCallResponse(UserCallTargetDTO::HOST, moduleDestination, functionCallResponse);
+    UserCallResponseDTO userCallResponse(UserCallTargetDTO::HOST, moduleDestination,
+                                         functionCallResponse);
     ResponseDTO response(responseId, userCallResponse);
     MessageDTO responseMessage(msgSourceId, msgDestinationId, response);
 

--- a/src/hiveboard_bridge/src/ReceiveAction.cpp
+++ b/src/hiveboard_bridge/src/ReceiveAction.cpp
@@ -6,10 +6,10 @@ ReceiveAction::ReceiveAction(IHiveMindHostDeserializer& deserializer,
     m_deserializer(deserializer), m_serializer(serializer), m_messageHandler(messageHandler) {}
 
 void ReceiveAction::fetchAndProcessMessage() {
-    std::variant<std::monostate, MessageDTO> message = m_deserializer.deserializeFromStream();
-    if (std::holds_alternative<MessageDTO>(message)) {
+    MessageDTO message;
+    if (m_deserializer.deserializeFromStream(message)) {
         // Execute the action
-        MessageDTO responseMessage = m_messageHandler.handleMessage(std::get<MessageDTO>(message));
+        MessageDTO responseMessage = m_messageHandler.handleMessage(message);
 
         // Send the ack/nack message
         m_serializer.serializeToStream(responseMessage);

--- a/src/hiveboard_bridge/src/ReceiveAction.cpp
+++ b/src/hiveboard_bridge/src/ReceiveAction.cpp
@@ -1,15 +1,18 @@
 #include "hiveboard_bridge/ReceiveAction.h"
 
 ReceiveAction::ReceiveAction(IHiveMindHostDeserializer& deserializer,
+                             IHiveMindHostSerializer& serializer,
                              IMessageHandler& messageHandler) :
-    m_deserializer(deserializer), m_messageHandler(messageHandler) {}
+    m_deserializer(deserializer), m_serializer(serializer), m_messageHandler(messageHandler) {}
 
 void ReceiveAction::fetchAndProcessMessage() {
     std::variant<std::monostate, MessageDTO> message = m_deserializer.deserializeFromStream();
     if (std::holds_alternative<MessageDTO>(message)) {
-        if (!m_messageHandler.handleMessage(std::get<MessageDTO>(message))) {
-            ROS_WARN("Message handling failed.");
-        }
+        // Execute the action
+        MessageDTO responseMessage = m_messageHandler.handleMessage(std::get<MessageDTO>(message));
+
+        // Send the ack/nack message
+        m_serializer.serializeToStream(responseMessage);
     } else {
         ROS_WARN("The received bytes do not contain a valid message.");
     }

--- a/src/hiveboard_bridge/src/main.cpp
+++ b/src/hiveboard_bridge/src/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv) {
     MessageHandler messageHandler;
 
     // Register callbacks
-    CallbackFunction moveByCallback = [&](CallbackArgs args, int argsLength, CallbackContext ctx) {
+    CallbackFunction moveByCallback = [&](CallbackArgs args, int argsLength) {
         swarmus_ros_navigation::MoveByMessage moveByMessage;
 
         moveByMessage.distance_x = std::get<float>(args[0].getArgument());

--- a/src/hiveboard_bridge/src/main.cpp
+++ b/src/hiveboard_bridge/src/main.cpp
@@ -45,18 +45,11 @@ int main(int argc, char** argv) {
 
         // Publish on moveby
         moveByPublisher.publish(moveByMessage);
-
-        // Send ack/response
-        FunctionCallResponseDTO functionCallResponse(GenericResponseStatusDTO::Ok, "");
-        UserCallResponseDTO userCallResponse(UserCallDestinationDTO::BUZZ, functionCallResponse);
-        ResponseDTO response(ctx.expectedResponseId, userCallResponse);
-        MessageDTO responseMessage(compoundId, ctx.compoundSourceId, response);
-        serializer.serializeToStream(responseMessage);
     };
 
     messageHandler.registerCallback("moveBy", moveByCallback);
 
-    ReceiveAction receiveAction(deserializer, messageHandler);
+    ReceiveAction receiveAction(deserializer, serializer, messageHandler);
 
     ros::Rate loopRate(RATE_HZ);
     while (ros::ok()) {

--- a/src/hiveboard_bridge/test/MessageHandlerUnitTest.cpp
+++ b/src/hiveboard_bridge/test/MessageHandlerUnitTest.cpp
@@ -57,15 +57,15 @@ class MessageHandlerFixture : public testing::Test {
         // Existing void  function
         m_functionCallRequestDto =
             new FunctionCallRequestDTO("TestFunctionCallRequestDTO", nullptr, 0);
-        m_userCallRequestDto =
-            new UserCallRequestDTO(UserCallTargetDTO::BUZZ, UserCallTargetDTO::HOST, *m_functionCallRequestDto);
+        m_userCallRequestDto = new UserCallRequestDTO(
+            UserCallTargetDTO::BUZZ, UserCallTargetDTO::HOST, *m_functionCallRequestDto);
         m_requestDto = new RequestDTO(1, *m_userCallRequestDto);
         m_messageDto = new MessageDTO(99, 2, *m_requestDto);
 
         // Nonexisting void function
         m_nonExistingFunctionCallRequestDto = new FunctionCallRequestDTO("NonExisting", nullptr, 0);
         m_nonExistingUserCallRequestDto = new UserCallRequestDTO(
-                UserCallTargetDTO::BUZZ, UserCallTargetDTO::HOST, *m_nonExistingFunctionCallRequestDto);
+            UserCallTargetDTO::BUZZ, UserCallTargetDTO::HOST, *m_nonExistingFunctionCallRequestDto);
         m_nonExistingRequestDto = new RequestDTO(1, *m_nonExistingUserCallRequestDto);
         m_nonExistingMessageDto = new MessageDTO(99, 2, *m_nonExistingRequestDto);
 
@@ -75,7 +75,7 @@ class MessageHandlerFixture : public testing::Test {
         FunctionCallArgumentDTO args[2] = {*m_sideEffectArg1, *m_sideEffectArg2};
         m_sideEffectFunctionCallRequestDto = new FunctionCallRequestDTO("MoveBy", args, 2);
         m_sideEffectUserCallRequestDto = new UserCallRequestDTO(
-                UserCallTargetDTO::BUZZ, UserCallTargetDTO::HOST, *m_sideEffectFunctionCallRequestDto);
+            UserCallTargetDTO::BUZZ, UserCallTargetDTO::HOST, *m_sideEffectFunctionCallRequestDto);
         m_sideEffectRequestDto = new RequestDTO(1, *m_sideEffectUserCallRequestDto);
         m_moveByMessageDto = new MessageDTO(99, 2, *m_sideEffectRequestDto);
     }

--- a/src/hiveboard_bridge/test/MessageHandlerUnitTest.cpp
+++ b/src/hiveboard_bridge/test/MessageHandlerUnitTest.cpp
@@ -24,11 +24,10 @@ class MessageHandlerFixture : public testing::Test {
         m_testFunctionCalled = true;
     };
 
-    CallbackFunction m_moveByTestCallback =
-        [&](CallbackArgs args, int argsLength) {
-            m_testValue1 += std::get<int64_t>(args[0].getArgument());
-            m_testValue2 -= std::get<float>(args[1].getArgument());
-        };
+    CallbackFunction m_moveByTestCallback = [&](CallbackArgs args, int argsLength) {
+        m_testValue1 += std::get<int64_t>(args[0].getArgument());
+        m_testValue2 -= std::get<float>(args[1].getArgument());
+    };
 
     MessageHandler m_messageHandler;
 

--- a/src/hiveboard_bridge/test/MessageHandlerUnitTest.cpp
+++ b/src/hiveboard_bridge/test/MessageHandlerUnitTest.cpp
@@ -126,12 +126,36 @@ TEST_F(MessageHandlerFixture, testGetCallbackFail) {
 
 TEST_F(MessageHandlerFixture, testHandleMessageVoidFunctionSuccess) {
     m_messageHandler.registerCallback("TestFunctionCallRequestDTO", m_testFunction);
-    ASSERT_TRUE(m_messageHandler.handleMessage(*m_messageDto));
+    MessageDTO responseMessage = m_messageHandler.handleMessage(*m_messageDto);
+    ASSERT_EQ(responseMessage.getSourceId(), 2);
+    ASSERT_EQ(responseMessage.getDestinationId(), 99);
+
+    ResponseDTO response = std::get<ResponseDTO>(responseMessage.getMessage());
+    ASSERT_EQ(response.getId(), 1);
+
+    UserCallResponseDTO userCallResponse = std::get<UserCallResponseDTO>(response.getResponse());
+    FunctionCallResponseDTO functionCallResponse =
+        std::get<FunctionCallResponseDTO>(userCallResponse.getResponse());
+    GenericResponseDTO genericResponse = functionCallResponse.getResponse();
+    ASSERT_EQ(genericResponse.getStatus(), GenericResponseStatusDTO::Ok);
+
     ASSERT_TRUE(m_testFunctionCalled);
 }
 
 TEST_F(MessageHandlerFixture, TestHandleMessageMoveByFunctionSuccess) {
-    ASSERT_TRUE(m_messageHandler.handleMessage(*m_moveByMessageDto));
+    MessageDTO responseMessage = m_messageHandler.handleMessage(*m_moveByMessageDto);
+    ASSERT_EQ(responseMessage.getSourceId(), 2);
+    ASSERT_EQ(responseMessage.getDestinationId(), 99);
+
+    ResponseDTO response = std::get<ResponseDTO>(responseMessage.getMessage());
+    ASSERT_EQ(response.getId(), 1);
+
+    UserCallResponseDTO userCallResponse = std::get<UserCallResponseDTO>(response.getResponse());
+    FunctionCallResponseDTO functionCallResponse =
+        std::get<FunctionCallResponseDTO>(userCallResponse.getResponse());
+    GenericResponseDTO genericResponse = functionCallResponse.getResponse();
+    ASSERT_EQ(genericResponse.getStatus(), GenericResponseStatusDTO::Ok);
+
     ASSERT_EQ(m_testValue1, 1);
     ASSERT_EQ(m_testValue2, 7);
     ASSERT_EQ(m_testcompoundSourceId, 99);
@@ -141,5 +165,16 @@ TEST_F(MessageHandlerFixture, TestHandleMessageMoveByFunctionSuccess) {
 }
 
 TEST_F(MessageHandlerFixture, testHandleMessageFail) {
-    ASSERT_FALSE(m_messageHandler.handleMessage(*m_nonExistingMessageDto));
+    MessageDTO responseMessage = m_messageHandler.handleMessage(*m_nonExistingMessageDto);
+    ASSERT_EQ(responseMessage.getSourceId(), 2);
+    ASSERT_EQ(responseMessage.getDestinationId(), 99);
+
+    ResponseDTO response = std::get<ResponseDTO>(responseMessage.getMessage());
+    ASSERT_EQ(response.getId(), 1);
+
+    UserCallResponseDTO userCallResponse = std::get<UserCallResponseDTO>(response.getResponse());
+    FunctionCallResponseDTO functionCallResponse =
+        std::get<FunctionCallResponseDTO>(userCallResponse.getResponse());
+    GenericResponseDTO genericResponse = functionCallResponse.getResponse();
+    ASSERT_EQ(genericResponse.getStatus(), GenericResponseStatusDTO::Unknown);
 }

--- a/src/hiveboard_bridge/test/MessageHandlerUnitTest.cpp
+++ b/src/hiveboard_bridge/test/MessageHandlerUnitTest.cpp
@@ -20,19 +20,14 @@ class MessageHandlerFixture : public testing::Test {
     uint32_t m_testExpectedResponseId = 0;
 
     // Declare some test callbacks
-    CallbackFunction m_testFunction = [&](CallbackArgs args, int argsLength, CallbackContext ctx) {
+    CallbackFunction m_testFunction = [&](CallbackArgs args, int argsLength) {
         m_testFunctionCalled = true;
     };
 
     CallbackFunction m_moveByTestCallback =
-        [&](CallbackArgs args, int argsLength, CallbackContext ctx) {
+        [&](CallbackArgs args, int argsLength) {
             m_testValue1 += std::get<int64_t>(args[0].getArgument());
             m_testValue2 -= std::get<float>(args[1].getArgument());
-
-            m_testcompoundSourceId = ctx.compoundSourceId;
-            m_testCompoundDestinationId = ctx.compoundDestinationId;
-            m_testModuleDestinationId = ctx.moduleDestinationId;
-            m_testExpectedResponseId = ctx.expectedResponseId;
         };
 
     MessageHandler m_messageHandler;
@@ -158,10 +153,6 @@ TEST_F(MessageHandlerFixture, TestHandleMessageMoveByFunctionSuccess) {
 
     ASSERT_EQ(m_testValue1, 1);
     ASSERT_EQ(m_testValue2, 7);
-    ASSERT_EQ(m_testcompoundSourceId, 99);
-    ASSERT_EQ(m_testCompoundDestinationId, 2);
-    ASSERT_EQ(m_testModuleDestinationId, UserCallDestinationDTO::HOST);
-    ASSERT_EQ(m_testExpectedResponseId, 1);
 }
 
 TEST_F(MessageHandlerFixture, testHandleMessageFail) {

--- a/src/hiveboard_bridge/test/MessageHandlerUnitTest.cpp
+++ b/src/hiveboard_bridge/test/MessageHandlerUnitTest.cpp
@@ -16,7 +16,7 @@ class MessageHandlerFixture : public testing::Test {
     int m_testValue2 = 12;
     uint32_t m_testcompoundSourceId = 0;
     uint32_t m_testCompoundDestinationId = 0;
-    UserCallDestinationDTO m_testModuleDestinationId = UserCallDestinationDTO::UNKNOWN;
+    UserCallTargetDTO m_testModuleDestinationId = UserCallTargetDTO::UNKNOWN;
     uint32_t m_testExpectedResponseId = 0;
 
     // Declare some test callbacks
@@ -58,14 +58,14 @@ class MessageHandlerFixture : public testing::Test {
         m_functionCallRequestDto =
             new FunctionCallRequestDTO("TestFunctionCallRequestDTO", nullptr, 0);
         m_userCallRequestDto =
-            new UserCallRequestDTO(UserCallDestinationDTO::HOST, *m_functionCallRequestDto);
+            new UserCallRequestDTO(UserCallTargetDTO::BUZZ, UserCallTargetDTO::HOST, *m_functionCallRequestDto);
         m_requestDto = new RequestDTO(1, *m_userCallRequestDto);
         m_messageDto = new MessageDTO(99, 2, *m_requestDto);
 
         // Nonexisting void function
         m_nonExistingFunctionCallRequestDto = new FunctionCallRequestDTO("NonExisting", nullptr, 0);
         m_nonExistingUserCallRequestDto = new UserCallRequestDTO(
-            UserCallDestinationDTO::HOST, *m_nonExistingFunctionCallRequestDto);
+                UserCallTargetDTO::BUZZ, UserCallTargetDTO::HOST, *m_nonExistingFunctionCallRequestDto);
         m_nonExistingRequestDto = new RequestDTO(1, *m_nonExistingUserCallRequestDto);
         m_nonExistingMessageDto = new MessageDTO(99, 2, *m_nonExistingRequestDto);
 
@@ -75,7 +75,7 @@ class MessageHandlerFixture : public testing::Test {
         FunctionCallArgumentDTO args[2] = {*m_sideEffectArg1, *m_sideEffectArg2};
         m_sideEffectFunctionCallRequestDto = new FunctionCallRequestDTO("MoveBy", args, 2);
         m_sideEffectUserCallRequestDto = new UserCallRequestDTO(
-            UserCallDestinationDTO::HOST, *m_sideEffectFunctionCallRequestDto);
+                UserCallTargetDTO::BUZZ, UserCallTargetDTO::HOST, *m_sideEffectFunctionCallRequestDto);
         m_sideEffectRequestDto = new RequestDTO(1, *m_sideEffectUserCallRequestDto);
         m_moveByMessageDto = new MessageDTO(99, 2, *m_sideEffectRequestDto);
     }
@@ -128,6 +128,8 @@ TEST_F(MessageHandlerFixture, testHandleMessageVoidFunctionSuccess) {
     ASSERT_EQ(response.getId(), 1);
 
     UserCallResponseDTO userCallResponse = std::get<UserCallResponseDTO>(response.getResponse());
+    ASSERT_EQ(userCallResponse.getDestination(), UserCallTargetDTO::BUZZ);
+
     FunctionCallResponseDTO functionCallResponse =
         std::get<FunctionCallResponseDTO>(userCallResponse.getResponse());
     GenericResponseDTO genericResponse = functionCallResponse.getResponse();
@@ -145,6 +147,8 @@ TEST_F(MessageHandlerFixture, TestHandleMessageMoveByFunctionSuccess) {
     ASSERT_EQ(response.getId(), 1);
 
     UserCallResponseDTO userCallResponse = std::get<UserCallResponseDTO>(response.getResponse());
+    ASSERT_EQ(userCallResponse.getDestination(), UserCallTargetDTO::BUZZ);
+
     FunctionCallResponseDTO functionCallResponse =
         std::get<FunctionCallResponseDTO>(userCallResponse.getResponse());
     GenericResponseDTO genericResponse = functionCallResponse.getResponse();
@@ -163,6 +167,8 @@ TEST_F(MessageHandlerFixture, testHandleMessageFail) {
     ASSERT_EQ(response.getId(), 1);
 
     UserCallResponseDTO userCallResponse = std::get<UserCallResponseDTO>(response.getResponse());
+    ASSERT_EQ(userCallResponse.getDestination(), UserCallTargetDTO::BUZZ);
+
     FunctionCallResponseDTO functionCallResponse =
         std::get<FunctionCallResponseDTO>(userCallResponse.getResponse());
     GenericResponseDTO genericResponse = functionCallResponse.getResponse();

--- a/src/hiveboard_bridge/test/ReceiveThreadActionUnitTest.cpp
+++ b/src/hiveboard_bridge/test/ReceiveThreadActionUnitTest.cpp
@@ -23,7 +23,7 @@ class ReceiveActionUnitFixture : public testing::Test {
         m_functionCallRequestDto =
             new FunctionCallRequestDTO("TestFunctionCallRequestDTO", nullptr, 0);
         m_userCallRequestDto =
-            new UserCallRequestDTO(UserCallDestinationDTO::HOST, *m_functionCallRequestDto);
+            new UserCallRequestDTO(UserCallTargetDTO::BUZZ, UserCallTargetDTO::HOST, *m_functionCallRequestDto);
         m_requestDto = new RequestDTO(1, *m_userCallRequestDto);
         m_messageDto = new MessageDTO(1, 2, *m_requestDto);
         m_messageVariant = new std::variant<std::monostate, MessageDTO>(*m_messageDto);
@@ -43,11 +43,11 @@ class ReceiveActionUnitFixture : public testing::Test {
 };
 
 TEST_F(ReceiveActionUnitFixture, receiveValidMessage) {
-    EXPECT_CALL(m_deserializer, deserializeFromStream())
-        .WillOnce(testing::Return(*m_messageVariant));
+    EXPECT_CALL(m_deserializer, deserializeFromStream(testing::_))
+        .WillOnce(testing::Return(true));
 
     MessageDTO responseMessage = MessageUtils::createResponseMessage(
-        1, 1, 1, UserCallDestinationDTO::UNKNOWN, GenericResponseStatusDTO::Ok, "");
+        1, 1, 1, UserCallTargetDTO::HOST, GenericResponseStatusDTO::Ok, "");
     EXPECT_CALL(m_messageHandler, handleMessage(testing::_))
         .WillOnce(testing::Return(responseMessage));
 
@@ -55,8 +55,8 @@ TEST_F(ReceiveActionUnitFixture, receiveValidMessage) {
 }
 
 TEST_F(ReceiveActionUnitFixture, receiveNoMessage) {
-    EXPECT_CALL(m_deserializer, deserializeFromStream())
-        .WillOnce(testing::Return(m_messageVariantEmpty));
+    EXPECT_CALL(m_deserializer, deserializeFromStream(testing::_))
+        .WillOnce(testing::Return(false));
     EXPECT_CALL(m_messageHandler, handleMessage(testing::_)).Times(0);
 
     m_receiveAction->fetchAndProcessMessage();

--- a/src/hiveboard_bridge/test/ReceiveThreadActionUnitTest.cpp
+++ b/src/hiveboard_bridge/test/ReceiveThreadActionUnitTest.cpp
@@ -22,8 +22,8 @@ class ReceiveActionUnitFixture : public testing::Test {
     void SetUp() {
         m_functionCallRequestDto =
             new FunctionCallRequestDTO("TestFunctionCallRequestDTO", nullptr, 0);
-        m_userCallRequestDto =
-            new UserCallRequestDTO(UserCallTargetDTO::BUZZ, UserCallTargetDTO::HOST, *m_functionCallRequestDto);
+        m_userCallRequestDto = new UserCallRequestDTO(
+            UserCallTargetDTO::BUZZ, UserCallTargetDTO::HOST, *m_functionCallRequestDto);
         m_requestDto = new RequestDTO(1, *m_userCallRequestDto);
         m_messageDto = new MessageDTO(1, 2, *m_requestDto);
         m_messageVariant = new std::variant<std::monostate, MessageDTO>(*m_messageDto);
@@ -43,8 +43,7 @@ class ReceiveActionUnitFixture : public testing::Test {
 };
 
 TEST_F(ReceiveActionUnitFixture, receiveValidMessage) {
-    EXPECT_CALL(m_deserializer, deserializeFromStream(testing::_))
-        .WillOnce(testing::Return(true));
+    EXPECT_CALL(m_deserializer, deserializeFromStream(testing::_)).WillOnce(testing::Return(true));
 
     MessageDTO responseMessage = MessageUtils::createResponseMessage(
         1, 1, 1, UserCallTargetDTO::HOST, GenericResponseStatusDTO::Ok, "");
@@ -55,8 +54,7 @@ TEST_F(ReceiveActionUnitFixture, receiveValidMessage) {
 }
 
 TEST_F(ReceiveActionUnitFixture, receiveNoMessage) {
-    EXPECT_CALL(m_deserializer, deserializeFromStream(testing::_))
-        .WillOnce(testing::Return(false));
+    EXPECT_CALL(m_deserializer, deserializeFromStream(testing::_)).WillOnce(testing::Return(false));
     EXPECT_CALL(m_messageHandler, handleMessage(testing::_)).Times(0);
 
     m_receiveAction->fetchAndProcessMessage();

--- a/src/hiveboard_bridge/test/SocketToMoveByIntegrationTest.cpp
+++ b/src/hiveboard_bridge/test/SocketToMoveByIntegrationTest.cpp
@@ -63,7 +63,8 @@ int main(int argc, char** argv) {
     FunctionCallArgumentDTO moveByY((float)1);
     FunctionCallArgumentDTO args[2] = {moveByX, moveByY};
     FunctionCallRequestDTO moveByFunctionCallRequestDTO("moveBy", args, 2);
-    UserCallRequestDTO userCallRequest(UserCallTargetDTO::UNKNOWN, UserCallTargetDTO::HOST, moveByFunctionCallRequestDTO);
+    UserCallRequestDTO userCallRequest(UserCallTargetDTO::UNKNOWN, UserCallTargetDTO::HOST,
+                                       moveByFunctionCallRequestDTO);
     RequestDTO moveByRequestDTO(1, userCallRequest);
     MessageDTO moveByMessageDTO(1, 2, moveByRequestDTO);
 

--- a/src/hiveboard_bridge/test/SocketToMoveByIntegrationTest.cpp
+++ b/src/hiveboard_bridge/test/SocketToMoveByIntegrationTest.cpp
@@ -63,7 +63,7 @@ int main(int argc, char** argv) {
     FunctionCallArgumentDTO moveByY((float)1);
     FunctionCallArgumentDTO args[2] = {moveByX, moveByY};
     FunctionCallRequestDTO moveByFunctionCallRequestDTO("moveBy", args, 2);
-    UserCallRequestDTO userCallRequest(UserCallDestinationDTO::HOST, moveByFunctionCallRequestDTO);
+    UserCallRequestDTO userCallRequest(UserCallTargetDTO::UNKNOWN, UserCallTargetDTO::HOST, moveByFunctionCallRequestDTO);
     RequestDTO moveByRequestDTO(1, userCallRequest);
     MessageDTO moveByMessageDTO(1, 2, moveByRequestDTO);
 
@@ -73,7 +73,8 @@ int main(int argc, char** argv) {
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
         // Listen for a response
-        MessageDTO message = std::get<MessageDTO>(deserializer.deserializeFromStream());
+        MessageDTO message;
+        deserializer.deserializeFromStream(message);
         ResponseDTO response = std::get<ResponseDTO>(message.getMessage());
         UserCallResponseDTO userCallResponse =
             std::get<UserCallResponseDTO>(response.getResponse());

--- a/src/hiveboard_bridge/test/mocks/HiveMindHostDeserializerInterfaceMock.h
+++ b/src/hiveboard_bridge/test/mocks/HiveMindHostDeserializerInterfaceMock.h
@@ -8,7 +8,7 @@ class HiveMindHostDeserializerInterfaceMock : public IHiveMindHostDeserializer {
   public:
     ~HiveMindHostDeserializerInterfaceMock() = default;
 
-    MOCK_METHOD((std::variant<std::monostate, MessageDTO>), deserializeFromStream, (), (override));
+    MOCK_METHOD(bool, deserializeFromStream, (MessageDTO& message), (override));
 };
 
 #endif // HIVEBOARD_BRIDGE_HIVEMINDHOSTDESERIALIZERINTERFACEMOCK_H

--- a/src/hiveboard_bridge/test/mocks/HiveMindHostDeserializerInterfaceMock.h
+++ b/src/hiveboard_bridge/test/mocks/HiveMindHostDeserializerInterfaceMock.h
@@ -8,7 +8,7 @@ class HiveMindHostDeserializerInterfaceMock : public IHiveMindHostDeserializer {
   public:
     ~HiveMindHostDeserializerInterfaceMock() = default;
 
-    MOCK_METHOD(bool, deserializeFromStream, (MessageDTO& message), (override));
+    MOCK_METHOD(bool, deserializeFromStream, (MessageDTO & message), (override));
 };
 
 #endif // HIVEBOARD_BRIDGE_HIVEMINDHOSTDESERIALIZERINTERFACEMOCK_H

--- a/src/hiveboard_bridge/test/mocks/HiveMindHostSerializerInterfaceMock.h
+++ b/src/hiveboard_bridge/test/mocks/HiveMindHostSerializerInterfaceMock.h
@@ -1,0 +1,14 @@
+#ifndef HIVEBOARD_BRIDGE_HIVEMINDHOSTSERIALIZERINTERFACEMOCK_H
+#define HIVEBOARD_BRIDGE_HIVEMINDHOSTSERIALIZERINTERFACEMOCK_H
+
+#include <gmock/gmock.h>
+#include <hivemind-host/IHiveMindHostSerializer.h>
+
+class HiveMindHostSerializerInterfaceMock : public IHiveMindHostSerializer {
+  public:
+    ~HiveMindHostSerializerInterfaceMock() = default;
+
+    MOCK_METHOD((bool), serializeToStream, (const MessageDTO& message), (override));
+};
+
+#endif // HIVEBOARD_BRIDGE_HIVEMINDHOSTSERIALIZERINTERFACEMOCK_H

--- a/src/hiveboard_bridge/test/mocks/MessageHandlerInterfaceMock.h
+++ b/src/hiveboard_bridge/test/mocks/MessageHandlerInterfaceMock.h
@@ -9,7 +9,7 @@ class MessageHandlerInterfaceMock : public IMessageHandler {
   public:
     ~MessageHandlerInterfaceMock() = default;
 
-    MOCK_METHOD(bool, handleMessage, (MessageDTO message), (override));
+    MOCK_METHOD(MessageDTO, handleMessage, (MessageDTO message), (override));
 
     MOCK_METHOD(bool, registerCallback, (std::string name, CallbackFunction callback), (override));
 


### PR DESCRIPTION
Change the logic for the ack/error messages.
* The response is now sent from the `ReceiveAction` directly, so the user does not need to worry about the acks.
* The `handelMessage` method now returns the appropriate response wrapped in a `MessageDTO` with all the values necessary (status, ids, destinations, etc.).