### PR TITLE
Feat/swarinfo 239 return data async

### DIFF
--- a/src/hive_mind_bridge/CMakeLists.txt
+++ b/src/hive_mind_bridge/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.13)
 project(hive_mind_bridge)
 set (CMAKE_CXX_STANDARD 17)
 
@@ -44,8 +44,7 @@ add_library(${LIB_ALIAS} ALIAS ${LIB_NAME})
 target_link_libraries(${LIB_NAME}
         ${catkin_LIBRARIES}
         SwarmUS::Propolis::Pheromones::HiveMind::Host
-        SwarmUS::Propolis::OS::Common
-        SwarmUS::Propolis::OS::POSIX
+        SwarmUS::Propolis::Pheromones::HiveMind::Host
         )
 
 # Main
@@ -95,14 +94,12 @@ target_link_libraries(HiveMindBridgeImplUnitTest
         )
 
 # Integration testing
-#add_executable(SocketToMoveByIntegrationTest
-#        test/SocketToMoveByIntegrationTest.cpp
-#        )
-#
-#target_link_libraries(SocketToMoveByIntegrationTest
-#        ${catkin_LIBRARIES}
-#        ${LIB_NAME}
-#        SwarmUS::Propolis::Pheromones::HiveMind::Host
-#        SwarmUS::Propolis::OS::Common
-#        SwarmUS::Propolis::OS::POSIX
-#)
+add_executable(SocketToMoveByIntegrationTest
+        test/SocketToMoveByIntegrationTest.cpp
+        )
+
+target_link_libraries(SocketToMoveByIntegrationTest
+        ${catkin_LIBRARIES}
+        ${LIB_NAME}
+        SwarmUS::Propolis::Pheromones::HiveMind::Host
+)

--- a/src/hive_mind_bridge/CMakeLists.txt
+++ b/src/hive_mind_bridge/CMakeLists.txt
@@ -35,7 +35,8 @@ set(HIVEMIND_BRIDGE_SOURCES
         src/HiveMindBridge.cpp
         src/HiveMindBridgeImpl.cpp
         src/UserCallbackFunctionWrapper.cpp
-        src/UserCallbackArgumentDescription.cpp)
+        src/UserCallbackArgumentDescription.cpp
+        src/MessageHandlerResult.cpp)
 
 add_library(${LIB_NAME} STATIC ${HIVEMIND_BRIDGE_SOURCES})
 add_library(${LIB_ALIAS} ALIAS ${LIB_NAME})

--- a/src/hive_mind_bridge/CMakeLists.txt
+++ b/src/hive_mind_bridge/CMakeLists.txt
@@ -44,6 +44,8 @@ add_library(${LIB_ALIAS} ALIAS ${LIB_NAME})
 target_link_libraries(${LIB_NAME}
         ${catkin_LIBRARIES}
         SwarmUS::Propolis::Pheromones::HiveMind::Host
+        SwarmUS::Propolis::OS::Common
+        SwarmUS::Propolis::OS::POSIX
         )
 
 # Main
@@ -93,12 +95,14 @@ target_link_libraries(HiveMindBridgeImplUnitTest
         )
 
 # Integration testing
-add_executable(SocketToMoveByIntegrationTest
-        test/SocketToMoveByIntegrationTest.cpp
-        )
-
-target_link_libraries(SocketToMoveByIntegrationTest
-        ${catkin_LIBRARIES}
-        ${LIB_NAME}
-        SwarmUS::Propolis::Pheromones::HiveMind::Host
-)
+#add_executable(SocketToMoveByIntegrationTest
+#        test/SocketToMoveByIntegrationTest.cpp
+#        )
+#
+#target_link_libraries(SocketToMoveByIntegrationTest
+#        ${catkin_LIBRARIES}
+#        ${LIB_NAME}
+#        SwarmUS::Propolis::Pheromones::HiveMind::Host
+#        SwarmUS::Propolis::OS::Common
+#        SwarmUS::Propolis::OS::POSIX
+#)

--- a/src/hive_mind_bridge/CMakeLists.txt
+++ b/src/hive_mind_bridge/CMakeLists.txt
@@ -44,7 +44,6 @@ add_library(${LIB_ALIAS} ALIAS ${LIB_NAME})
 target_link_libraries(${LIB_NAME}
         ${catkin_LIBRARIES}
         SwarmUS::Propolis::Pheromones::HiveMind::Host
-        SwarmUS::Propolis::Pheromones::HiveMind::Host
         )
 
 # Main

--- a/src/hive_mind_bridge/cmake/propolis.cmake
+++ b/src/hive_mind_bridge/cmake/propolis.cmake
@@ -27,7 +27,7 @@ function(propolis_fetch_populate)
         FetchContent_Populate(${PROPOLIS})
 
         list(APPEND CMAKE_MODULE_PATH ${${PROPOLIS_L}_SOURCE_DIR}/cmake/)
-        add_subdirectory(${${PROPOLIS_L}_SOURCE_DIR}/src ${${PROPOLIS_L}_BINARY_DIR})
+        add_subdirectory(${${PROPOLIS_L}_SOURCE_DIR}/src/pheromones ${${PROPOLIS_L}_BINARY_DIR})
     endif()
 
 endfunction()

--- a/src/hive_mind_bridge/cmake/propolis.cmake
+++ b/src/hive_mind_bridge/cmake/propolis.cmake
@@ -11,7 +11,7 @@ function(propolis_fetch_populate)
             ${PROJECT_NAME}_propolis
 
             GIT_REPOSITORY https://github.com/SwarmUS/Propolis
-            GIT_TAG        84535d3157a3c2fe4fb2650592f03b8a2a6a8a0b
+            GIT_TAG        100de12d5f51d50857f5faa64b9b0545b9162aac
             GIT_PROGRESS   TRUE
     )
 
@@ -27,7 +27,7 @@ function(propolis_fetch_populate)
         FetchContent_Populate(${PROPOLIS})
 
         list(APPEND CMAKE_MODULE_PATH ${${PROPOLIS_L}_SOURCE_DIR}/cmake/)
-        add_subdirectory(${${PROPOLIS_L}_SOURCE_DIR}/src/pheromones ${${PROPOLIS_L}_BINARY_DIR})
+        add_subdirectory(${${PROPOLIS_L}_SOURCE_DIR}/src ${${PROPOLIS_L}_BINARY_DIR})
     endif()
 
 endfunction()

--- a/src/hive_mind_bridge/include/hive_mind_bridge/Callback.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/Callback.h
@@ -1,0 +1,35 @@
+#ifndef HIVE_MIND_BRIDGE_CALLBACK_H
+#define HIVE_MIND_BRIDGE_CALLBACK_H
+
+#include "hive_mind_bridge/UserCallbackArgumentDescription.h"
+#include <functional>
+#include <hivemind-host/FunctionCallArgumentDTO.h>
+#include <hivemind-host/FunctionCallRequestDTO.h>
+
+typedef std::array<FunctionCallArgumentDTO,
+                   FunctionCallRequestDTO::FUNCTION_CALL_ARGUMENTS_MAX_LENGTH>
+    CallbackArgs;
+
+typedef std::vector<UserCallbackArgumentDescription> CallbackArgsManifest;
+
+/**
+ * The return type of a user callback.
+ */
+class CallbackReturn {
+  public:
+    CallbackReturn(std::string returnFunctionName, CallbackArgs args) :
+        m_args(args), m_returnFunctionName(returnFunctionName) {}
+
+    CallbackArgs getReturnArgs() { return m_args; }
+
+    std::string getReturnFunctionName() { return m_returnFunctionName; }
+
+  private:
+    CallbackArgs m_args; // The return values
+    std::string
+        m_returnFunctionName; // The name of the function call request in which to wrap the response
+};
+
+typedef std::function<std::optional<CallbackReturn>(CallbackArgs, int)> CallbackFunction;
+
+#endif // HIVE_MIND_BRIDGE_CALLBACK_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridge.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridge.h
@@ -34,6 +34,7 @@ class HiveMindBridge : public IHiveMindBridge {
     TCPServer m_tcpServer;
     HiveMindHostDeserializer m_deserializer;
     HiveMindHostSerializer m_serializer;
+    MessageHandler m_messageHandler;
     ThreadSafeQueue<MessageDTO> m_inboundQueue;
 };
 

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridge.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridge.h
@@ -4,6 +4,7 @@
 #include "hive_mind_bridge/IHiveMindBridge.h"
 #include "hive_mind_bridge/MessageHandler.h"
 #include "hive_mind_bridge/TCPServer.h"
+#include "hive_mind_bridge/ThreadSafeQueue.h"
 #include <hivemind-host/HiveMindHostDeserializer.h>
 #include <hivemind-host/HiveMindHostSerializer.h>
 #include <memory>

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridge.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridge.h
@@ -33,6 +33,7 @@ class HiveMindBridge : public IHiveMindBridge {
     TCPServer m_tcpServer;
     HiveMindHostDeserializer m_deserializer;
     HiveMindHostSerializer m_serializer;
+    ThreadSafeQueue<MessageDTO> m_inboundQueue;
 };
 
 #endif // HIVEMIND_BRIDGE_HIVEMINDBRIDGE_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridge.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridge.h
@@ -33,6 +33,7 @@ class HiveMindBridge : public IHiveMindBridge {
     TCPServer m_tcpServer;
     HiveMindHostDeserializer m_deserializer;
     HiveMindHostSerializer m_serializer;
+
 };
 
 #endif // HIVEMIND_BRIDGE_HIVEMINDBRIDGE_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridge.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridge.h
@@ -33,7 +33,6 @@ class HiveMindBridge : public IHiveMindBridge {
     TCPServer m_tcpServer;
     HiveMindHostDeserializer m_deserializer;
     HiveMindHostSerializer m_serializer;
-
 };
 
 #endif // HIVEMIND_BRIDGE_HIVEMINDBRIDGE_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
@@ -5,7 +5,7 @@
 #include "hive_mind_bridge/MessageHandler.h"
 #include "hive_mind_bridge/MessageHandlerResult.h"
 #include "hive_mind_bridge/TCPServer.h"
-#include "hive_mind_bridge/ThreadSafeQueue.h"
+#include "hive_mind_bridge/IThreadSafeQueue.h"
 #include <deque>
 #include <hivemind-host/HiveMindHostDeserializer.h>
 #include <hivemind-host/HiveMindHostSerializer.h>
@@ -24,7 +24,7 @@ class HiveMindBridgeImpl : public IHiveMindBridge {
     HiveMindBridgeImpl(ITCPServer& tcpServer,
                        IHiveMindHostSerializer& serializer,
                        IHiveMindHostDeserializer& deserializer,
-                       ThreadSafeQueue<MessageDTO>& inboundQueue);
+                       IThreadSafeQueue<MessageDTO>& inboundQueue);
 
     void spin();
 
@@ -44,7 +44,7 @@ class HiveMindBridgeImpl : public IHiveMindBridge {
     IHiveMindHostSerializer& m_serializer;
     MessageHandler m_messageHandler;
 
-    ThreadSafeQueue<MessageDTO>& m_inboundQueue;
+    IThreadSafeQueue<MessageDTO>& m_inboundQueue;
     std::thread m_inboundThread;
     std::mutex m_mutex;
 

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
@@ -19,11 +19,14 @@ class HiveMindBridgeImpl : public IHiveMindBridge {
      * Construct a HiveMind Bridge object by injecting already-initialised objects.
      * @param tcpServer A TCPServer to be used
      * @param serializer A HiveMindHostSerializer to be used
+     * @param messageHandler A MessageHandler to be used
      * @param deserializer A HiveMindHostDeserializer to be used
+     * @param inboundQueue A ThreadSafeQueue to be  used
      */
     HiveMindBridgeImpl(ITCPServer& tcpServer,
                        IHiveMindHostSerializer& serializer,
                        IHiveMindHostDeserializer& deserializer,
+                       IMessageHandler& messageHandler,
                        IThreadSafeQueue<MessageDTO>& inboundQueue);
 
     void spin();
@@ -42,7 +45,7 @@ class HiveMindBridgeImpl : public IHiveMindBridge {
     ITCPServer& m_tcpServer;
     IHiveMindHostDeserializer& m_deserializer;
     IHiveMindHostSerializer& m_serializer;
-    MessageHandler m_messageHandler;
+    IMessageHandler& m_messageHandler;
 
     IThreadSafeQueue<MessageDTO>& m_inboundQueue;
     std::thread m_inboundThread;

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
@@ -8,6 +8,9 @@
 #include <hivemind-host/HiveMindHostDeserializer.h>
 #include <hivemind-host/HiveMindHostSerializer.h>
 #include <memory>
+#include "hive_mind_bridge/ThreadSafeQueue.h"
+#include <thread>
+#include <mutex>
 
 class HiveMindBridgeImpl : public IHiveMindBridge {
   public:
@@ -39,8 +42,14 @@ class HiveMindBridgeImpl : public IHiveMindBridge {
     IHiveMindHostSerializer& m_serializer;
     MessageHandler m_messageHandler;
 
-    std::future<bool> m_deserializerFuture;
+    ThreadSafeQueue<MessageDTO> m_inboundQueue;
+    std::unique_ptr<std::thread> m_inboundThread;
+    std::mutex m_mutex;
+
     MessageHandlerResult result; // todo change this
+
+    void inboundThread();
+    bool isTCPClientConnected();
 };
 
 #endif // HIVEMIND_BRIDGE_HIVEMINDBRIDGEIMPL_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
@@ -11,6 +11,7 @@
 #include "hive_mind_bridge/ThreadSafeQueue.h"
 #include <thread>
 #include <mutex>
+#include <deque>
 
 class HiveMindBridgeImpl : public IHiveMindBridge {
   public:
@@ -43,10 +44,12 @@ class HiveMindBridgeImpl : public IHiveMindBridge {
     MessageHandler m_messageHandler;
 
     ThreadSafeQueue<MessageDTO> m_inboundQueue;
-    std::unique_ptr<std::thread> m_inboundThread;
+    std::thread m_inboundThread;
     std::mutex m_mutex;
 
     MessageHandlerResult result; // todo change this
+
+    std::deque<std::shared_future<std::optional<CallbackArgs>>> m_futuresQueue;
 
     void inboundThread();
     bool isTCPClientConnected();

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
@@ -3,15 +3,15 @@
 
 #include "hive_mind_bridge/IHiveMindBridge.h"
 #include "hive_mind_bridge/MessageHandler.h"
-#include "hive_mind_bridge/TCPServer.h"
 #include "hive_mind_bridge/MessageHandlerResult.h"
+#include "hive_mind_bridge/TCPServer.h"
+#include "hive_mind_bridge/ThreadSafeQueue.h"
+#include <deque>
 #include <hivemind-host/HiveMindHostDeserializer.h>
 #include <hivemind-host/HiveMindHostSerializer.h>
 #include <memory>
-#include "hive_mind_bridge/ThreadSafeQueue.h"
-#include <thread>
 #include <mutex>
-#include <deque>
+#include <thread>
 
 class HiveMindBridgeImpl : public IHiveMindBridge {
   public:

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
@@ -38,6 +38,9 @@ class HiveMindBridgeImpl : public IHiveMindBridge {
     IHiveMindHostDeserializer& m_deserializer;
     IHiveMindHostSerializer& m_serializer;
     MessageHandler m_messageHandler;
+
+    std::future<bool> m_deserializerFuture;
+    MessageHandlerResult result; // todo change this
 };
 
 #endif // HIVEMIND_BRIDGE_HIVEMINDBRIDGEIMPL_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
@@ -47,12 +47,11 @@ class HiveMindBridgeImpl : public IHiveMindBridge {
     std::thread m_inboundThread;
     std::mutex m_mutex;
 
-    MessageHandlerResult result; // todo change this
-
-    std::deque<std::shared_future<std::optional<CallbackArgs>>> m_futuresQueue;
+    std::deque<MessageHandlerResult> m_resultQueue;
 
     void inboundThread();
     bool isTCPClientConnected();
+    void sendReturn(MessageHandlerResult result);
 };
 
 #endif // HIVEMIND_BRIDGE_HIVEMINDBRIDGEIMPL_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
@@ -1,6 +1,7 @@
 #ifndef HIVEMIND_BRIDGE_HIVEMINDBRIDGEIMPL_H
 #define HIVEMIND_BRIDGE_HIVEMINDBRIDGEIMPL_H
 
+#include "hive_mind_bridge/Callback.h"
 #include "hive_mind_bridge/IHiveMindBridge.h"
 #include "hive_mind_bridge/IThreadSafeQueue.h"
 #include "hive_mind_bridge/MessageHandler.h"

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
@@ -4,6 +4,7 @@
 #include "hive_mind_bridge/IHiveMindBridge.h"
 #include "hive_mind_bridge/MessageHandler.h"
 #include "hive_mind_bridge/TCPServer.h"
+#include "hive_mind_bridge/MessageHandlerResult.h"
 #include <hivemind-host/HiveMindHostDeserializer.h>
 #include <hivemind-host/HiveMindHostSerializer.h>
 #include <memory>

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
@@ -2,10 +2,10 @@
 #define HIVEMIND_BRIDGE_HIVEMINDBRIDGEIMPL_H
 
 #include "hive_mind_bridge/IHiveMindBridge.h"
+#include "hive_mind_bridge/IThreadSafeQueue.h"
 #include "hive_mind_bridge/MessageHandler.h"
 #include "hive_mind_bridge/MessageHandlerResult.h"
 #include "hive_mind_bridge/TCPServer.h"
-#include "hive_mind_bridge/IThreadSafeQueue.h"
 #include <deque>
 #include <hivemind-host/HiveMindHostDeserializer.h>
 #include <hivemind-host/HiveMindHostSerializer.h>

--- a/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/HiveMindBridgeImpl.h
@@ -23,7 +23,8 @@ class HiveMindBridgeImpl : public IHiveMindBridge {
      */
     HiveMindBridgeImpl(ITCPServer& tcpServer,
                        IHiveMindHostSerializer& serializer,
-                       IHiveMindHostDeserializer& deserializer);
+                       IHiveMindHostDeserializer& deserializer,
+                       ThreadSafeQueue<MessageDTO>& inboundQueue);
 
     void spin();
 
@@ -43,7 +44,7 @@ class HiveMindBridgeImpl : public IHiveMindBridge {
     IHiveMindHostSerializer& m_serializer;
     MessageHandler m_messageHandler;
 
-    ThreadSafeQueue<MessageDTO> m_inboundQueue;
+    ThreadSafeQueue<MessageDTO>& m_inboundQueue;
     std::thread m_inboundThread;
     std::mutex m_mutex;
 

--- a/src/hive_mind_bridge/include/hive_mind_bridge/IMessageHandler.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/IMessageHandler.h
@@ -1,6 +1,7 @@
 #ifndef HIVEMIND_BRIDGE_IMESSAGEHANDLER_H
 #define HIVEMIND_BRIDGE_IMESSAGEHANDLER_H
 
+#include "MessageHandlerResult.h"
 #include "hive_mind_bridge/UserCallbackFunctionWrapper.h"
 #include <hivemind-host/FunctionCallArgumentDTO.h>
 #include <hivemind-host/FunctionCallRequestDTO.h>
@@ -10,7 +11,6 @@
 #include <optional>
 #include <ros/ros.h>
 #include <variant>
-#include "MessageHandlerResult.h"
 
 typedef std::unordered_map<std::string, UserCallbackFunctionWrapper> CallbackMap;
 

--- a/src/hive_mind_bridge/include/hive_mind_bridge/IMessageHandler.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/IMessageHandler.h
@@ -10,6 +10,7 @@
 #include <optional>
 #include <ros/ros.h>
 #include <variant>
+#include "MessageHandlerResult.h"
 
 typedef std::unordered_map<std::string, UserCallbackFunctionWrapper> CallbackMap;
 
@@ -23,7 +24,7 @@ class IMessageHandler {
      * @return A message containing the appropriate acknowlege (with appropriate errors if
      * necessary)
      */
-    virtual MessageDTO handleMessage(MessageDTO message) = 0;
+    virtual MessageHandlerResult handleMessage(MessageDTO message) = 0;
 
     /**
      * Register a callback

--- a/src/hive_mind_bridge/include/hive_mind_bridge/IThreadSafeQueue.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/IThreadSafeQueue.h
@@ -3,7 +3,7 @@
 
 template <class T>
 class IThreadSafeQueue {
-public:
+  public:
     virtual void push(const T& item) = 0;
 
     virtual void pop() = 0;
@@ -17,4 +17,4 @@ public:
     virtual bool empty() = 0;
 };
 
-#endif //HIVE_MIND_BRIDGE_ITHREADSAFEQUEUE_H
+#endif // HIVE_MIND_BRIDGE_ITHREADSAFEQUEUE_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/IThreadSafeQueue.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/IThreadSafeQueue.h
@@ -1,0 +1,20 @@
+#ifndef HIVE_MIND_BRIDGE_ITHREADSAFEQUEUE_H
+#define HIVE_MIND_BRIDGE_ITHREADSAFEQUEUE_H
+
+template <class T>
+class IThreadSafeQueue {
+public:
+    virtual void push(const T& item) = 0;
+
+    virtual void pop() = 0;
+
+    virtual T front() = 0;
+
+    virtual T back() = 0;
+
+    virtual size_t size() = 0;
+
+    virtual bool empty() = 0;
+};
+
+#endif //HIVE_MIND_BRIDGE_ITHREADSAFEQUEUE_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandler.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandler.h
@@ -1,6 +1,7 @@
 #ifndef CATKIN_ROS_MESSAGEHANDLER_H
 #define CATKIN_ROS_MESSAGEHANDLER_H
 
+#include "Callback.h"
 #include "IMessageHandler.h"
 #include "hive_mind_bridge/MessageUtils.h"
 

--- a/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandler.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandler.h
@@ -9,7 +9,7 @@ class MessageHandler : public IMessageHandler {
     MessageHandler();
     ~MessageHandler();
 
-    MessageDTO handleMessage(MessageDTO message) override;
+    MessageHandlerResult handleMessage(MessageDTO message) override;
 
     bool registerCallback(std::string name, CallbackFunction callback) override;
 

--- a/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandlerResult.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandlerResult.h
@@ -1,14 +1,13 @@
 #ifndef HIVE_MIND_BRIDGE_MESSAGEHANDLERRESULT_H
 #define HIVE_MIND_BRIDGE_MESSAGEHANDLERRESULT_H
 
-#include <hivemind-host/MessageDTO.h>
-#include <future>
-#include <optional>
 #include "UserCallbackFunctionWrapper.h"
+#include <future>
+#include <hivemind-host/MessageDTO.h>
+#include <optional>
 
 class MessageHandlerResult {
-public:
-
+  public:
     MessageHandlerResult() = default;
 
     void setResponse(MessageDTO message);
@@ -20,6 +19,8 @@ public:
     void setMessageDestinationId(uint32_t id);
 
     void setSourceModule(UserCallTargetDTO target);
+
+    void setCallbackName(std::string name);
 
     MessageDTO getResponse();
 
@@ -33,7 +34,7 @@ public:
 
     UserCallTargetDTO getSourceModule();
 
-private:
+  private:
     std::string m_callbackName;
     MessageDTO m_responseMessage; // The acknowledge message to send as soon as possible
     std::shared_future<std::optional<CallbackArgs>> m_future;
@@ -43,4 +44,4 @@ private:
     UserCallTargetDTO m_sourceModule;
 };
 
-#endif //HIVE_MIND_BRIDGE_MESSAGEHANDLERRESULT_H
+#endif // HIVE_MIND_BRIDGE_MESSAGEHANDLERRESULT_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandlerResult.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandlerResult.h
@@ -1,18 +1,22 @@
 #ifndef HIVE_MIND_BRIDGE_MESSAGEHANDLERRESULT_H
 #define HIVE_MIND_BRIDGE_MESSAGEHANDLERRESULT_H
 
-#include "UserCallbackFunctionWrapper.h"
+#include "hive_mind_bridge/Callback.h"
+#include "hive_mind_bridge/UserCallbackFunctionWrapper.h"
 #include <future>
 #include <hivemind-host/MessageDTO.h>
 #include <optional>
 
+/**
+ * A class that contains various data to be returned by the handling of an incoming message.
+ */
 class MessageHandlerResult {
   public:
     MessageHandlerResult() = default;
 
     void setResponse(MessageDTO message);
 
-    void setFuture(std::shared_future<std::optional<CallbackArgs>> future);
+    void setCallbackReturnContext(std::shared_future<std::optional<CallbackReturn>> future);
 
     void setMessageSourceId(uint32_t id);
 
@@ -24,9 +28,7 @@ class MessageHandlerResult {
 
     MessageDTO getResponse();
 
-    std::shared_future<std::optional<CallbackArgs>> getFuture();
-
-    std::string getReturnCallbackName();
+    std::shared_future<std::optional<CallbackReturn>> getCallbackReturnContext();
 
     uint32_t getMessageSourceId();
 
@@ -35,9 +37,9 @@ class MessageHandlerResult {
     UserCallTargetDTO getSourceModule();
 
   private:
-    std::string m_callbackName;
+    std::string m_callbackName; // The name of the callback called by a functionCallRequest
     MessageDTO m_responseMessage; // The acknowledge message to send as soon as possible
-    std::shared_future<std::optional<CallbackArgs>> m_future;
+    std::shared_future<std::optional<CallbackReturn>> m_callbackReturnContext;
 
     uint32_t m_msgSourceId;
     uint32_t m_msgDestinationId;

--- a/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandlerResult.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandlerResult.h
@@ -1,0 +1,27 @@
+#ifndef HIVE_MIND_BRIDGE_MESSAGEHANDLERRESULT_H
+#define HIVE_MIND_BRIDGE_MESSAGEHANDLERRESULT_H
+
+#include <hivemind-host/MessageDTO.h>
+#include <future>
+#include <optional>
+#include "UserCallbackFunctionWrapper.h"
+
+class MessageHandlerResult {
+public:
+
+    MessageHandlerResult() = default;
+
+    void setResponse(MessageDTO message);
+
+    void setReturnValues(std::future<std::optional<CallbackArgs>> returnValues);
+
+    MessageDTO getResponse();
+
+    std::future<std::optional<CallbackArgs>> getReturnValues();
+
+private:
+    MessageDTO m_responseMessage;
+    std::future<std::optional<CallbackArgs>> m_returnValues;
+};
+
+#endif //HIVE_MIND_BRIDGE_MESSAGEHANDLERRESULT_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandlerResult.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandlerResult.h
@@ -15,13 +15,32 @@ public:
 
     void setFuture(std::shared_future<std::optional<CallbackArgs>> future);
 
+    void setMessageSourceId(uint32_t id);
+
+    void setMessageDestinationId(uint32_t id);
+
+    void setSourceModule(UserCallTargetDTO target);
+
     MessageDTO getResponse();
 
     std::shared_future<std::optional<CallbackArgs>> getFuture();
 
+    std::string getReturnCallbackName();
+
+    uint32_t getMessageSourceId();
+
+    uint32_t getMessageDestinationId();
+
+    UserCallTargetDTO getSourceModule();
+
 private:
-    MessageDTO m_responseMessage;
+    std::string m_callbackName;
+    MessageDTO m_responseMessage; // The acknowledge message to send as soon as possible
     std::shared_future<std::optional<CallbackArgs>> m_future;
+
+    uint32_t m_msgSourceId;
+    uint32_t m_msgDestinationId;
+    UserCallTargetDTO m_sourceModule;
 };
 
 #endif //HIVE_MIND_BRIDGE_MESSAGEHANDLERRESULT_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandlerResult.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandlerResult.h
@@ -13,15 +13,15 @@ public:
 
     void setResponse(MessageDTO message);
 
-    void setReturnValues(std::future<std::optional<CallbackArgs>> returnValues);
+    void setReturnValues(std::shared_future<std::optional<CallbackArgs>> returnValues);
 
     MessageDTO getResponse();
 
-    std::future<std::optional<CallbackArgs>> getReturnValues();
+    std::shared_future<std::optional<CallbackArgs>> getReturnValues();
 
 private:
     MessageDTO m_responseMessage;
-    std::future<std::optional<CallbackArgs>> m_returnValues;
+    std::shared_future<std::optional<CallbackArgs>> m_returnValues;
 };
 
 #endif //HIVE_MIND_BRIDGE_MESSAGEHANDLERRESULT_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandlerResult.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/MessageHandlerResult.h
@@ -13,15 +13,15 @@ public:
 
     void setResponse(MessageDTO message);
 
-    void setReturnValues(std::shared_future<std::optional<CallbackArgs>> returnValues);
+    void setFuture(std::shared_future<std::optional<CallbackArgs>> future);
 
     MessageDTO getResponse();
 
-    std::shared_future<std::optional<CallbackArgs>> getReturnValues();
+    std::shared_future<std::optional<CallbackArgs>> getFuture();
 
 private:
     MessageDTO m_responseMessage;
-    std::shared_future<std::optional<CallbackArgs>> m_returnValues;
+    std::shared_future<std::optional<CallbackArgs>> m_future;
 };
 
 #endif //HIVE_MIND_BRIDGE_MESSAGEHANDLERRESULT_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/MessageUtils.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/MessageUtils.h
@@ -19,7 +19,7 @@ namespace MessageUtils {
      * @param moduleDestination The module to which the response should be addressed.
      * @param status The status of the processing of the message
      * @param ackMessage A string containing some details.
-     * @return
+     * @return the created message
      */
     MessageDTO createResponseMessage(uint32_t responseId,
                                      uint32_t msgSourceId,
@@ -28,18 +28,46 @@ namespace MessageUtils {
                                      GenericResponseStatusDTO status,
                                      std::string ackMessage);
 
+    /**
+     * Create a response message for a FunctionListLength request
+     * @param responseId Id of the request responded to
+     * @param msgSourceId Source of the response. Should correspond to the ID of this device.
+     * @param msgDestinationId Destination of the response.
+     * @param moduleDestination The module to which the response should be addressed.
+     * @param length the length of the function list
+     * @return the created message
+     */
     MessageDTO createFunctionListLengthResponseMessage(uint32_t responseId,
                                                        uint32_t msgSourceId,
                                                        uint32_t msgDestinationId,
                                                        UserCallTargetDTO moduleDestination,
                                                        uint32_t length);
 
+    /**
+     * Create a response message for a FunctionDescription request
+     * @param responseId Id of the request responded to
+     * @param msgSourceId Source of the response. Should correspond to the ID of this device.
+     * @param msgDestinationId Destination of the response.
+     * @param moduleDestination The module to which the response should be addressed.
+     * @param functionDescription The description of the function
+     * @return the created message
+     */
     MessageDTO createFunctionDescriptionResponseMessage(uint32_t responseId,
                                                         uint32_t msgSourceId,
                                                         uint32_t msgDestinationId,
                                                         UserCallTargetDTO moduleDestination,
                                                         FunctionDescriptionDTO functionDescription);
 
+    /**
+     * Create a message with a Function call request with arguments
+     * @param msgSourceId The ID of this device
+     * @param msgDestinationId The ID of the target device
+     * @param requestId The ID of the request
+     * @param moduleDestination The module to send the message to
+     * @param callbackName The name of the function
+     * @param args The args to pass to the function
+     * @return the created message
+     */
     MessageDTO createFunctionCallRequest(uint32_t msgSourceId,
                                          uint32_t msgDestinationId,
                                          uint32_t requestId,
@@ -47,11 +75,25 @@ namespace MessageUtils {
                                          std::string callbackName,
                                          CallbackArgs args);
 
+    /**
+     * Create a message with a Function call request without arguments
+     * @param msgSourceId The ID of this device
+     * @param msgDestinationId The ID of the target device
+     * @param requestId The ID of the request
+     * @param moduleDestination The module to send the message to
+     * @param callbackName The name of the function
+     * @return the created message
+     */
     MessageDTO createFunctionCallRequest(uint32_t msgSourceId,
                                          uint32_t msgDestinationId,
                                          uint32_t requestId,
                                          UserCallTargetDTO moduleDestination,
                                          std::string callbackName);
+
+    /**
+     * Returns a suitable value to use as a requestId;
+     */
+    uint32_t generateRandomId();
 
 } // namespace MessageUtils
 

--- a/src/hive_mind_bridge/include/hive_mind_bridge/MessageUtils.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/MessageUtils.h
@@ -1,11 +1,11 @@
 #ifndef HIVEMIND_BRIDGE_MESSAGEUTILS_H
 #define HIVEMIND_BRIDGE_MESSAGEUTILS_H
 
+#include "hive_mind_bridge/UserCallbackFunctionWrapper.h"
 #include <hivemind-host/FunctionCallResponseDTO.h>
 #include <hivemind-host/MessageDTO.h>
 #include <hivemind-host/ResponseDTO.h>
 #include <hivemind-host/UserCallResponseDTO.h>
-#include "hive_mind_bridge/UserCallbackFunctionWrapper.h"
 
 /**
  * Utilitary functions for message creation
@@ -47,7 +47,11 @@ namespace MessageUtils {
                                          std::string callbackName,
                                          CallbackArgs args);
 
-    uint8_t createFunctionCallArguments(CallbackArgs args, FunctionCallArgumentDTO* functionCallArgument);
+    MessageDTO createFunctionCallRequest(uint32_t msgSourceId,
+                                         uint32_t msgDestinationId,
+                                         uint32_t requestId,
+                                         UserCallTargetDTO moduleDestination,
+                                         std::string callbackName);
 
 } // namespace MessageUtils
 

--- a/src/hive_mind_bridge/include/hive_mind_bridge/MessageUtils.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/MessageUtils.h
@@ -5,6 +5,7 @@
 #include <hivemind-host/MessageDTO.h>
 #include <hivemind-host/ResponseDTO.h>
 #include <hivemind-host/UserCallResponseDTO.h>
+#include "hive_mind_bridge/UserCallbackFunctionWrapper.h"
 
 /**
  * Utilitary functions for message creation
@@ -38,6 +39,16 @@ namespace MessageUtils {
                                                         uint32_t msgDestinationId,
                                                         UserCallTargetDTO moduleDestination,
                                                         FunctionDescriptionDTO functionDescription);
+
+    MessageDTO createFunctionCallRequest(uint32_t msgSourceId,
+                                         uint32_t msgDestinationId,
+                                         uint32_t requestId,
+                                         UserCallTargetDTO moduleDestination,
+                                         std::string callbackName,
+                                         CallbackArgs args);
+
+    uint8_t createFunctionCallArguments(CallbackArgs args, FunctionCallArgumentDTO* functionCallArgument);
+
 } // namespace MessageUtils
 
 #endif // HIVEMIND_BRIDGE_MESSAGEUTILS_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/TCPServer.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/TCPServer.h
@@ -73,6 +73,7 @@ class TCPServer : public ITCPServer {
     std::function<void()> m_onConnect;
     std::function<void()> m_onDisonnect;
 
+
     /**
      * Create and bind the socket.
      */

--- a/src/hive_mind_bridge/include/hive_mind_bridge/TCPServer.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/TCPServer.h
@@ -73,7 +73,6 @@ class TCPServer : public ITCPServer {
     std::function<void()> m_onConnect;
     std::function<void()> m_onDisonnect;
 
-
     /**
      * Create and bind the socket.
      */

--- a/src/hive_mind_bridge/include/hive_mind_bridge/ThreadSafeQueue.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/ThreadSafeQueue.h
@@ -1,12 +1,12 @@
 #ifndef HIVE_MIND_BRIDGE_THREADSAFEQUEUE_H
 #define HIVE_MIND_BRIDGE_THREADSAFEQUEUE_H
 
-#include <queue>
 #include <mutex>
+#include <queue>
 
-template<class T>
+template <class T>
 class ThreadSafeQueue {
-public:
+  public:
     ThreadSafeQueue() {}
 
     void push(const T& item) {
@@ -39,9 +39,9 @@ public:
         return m_queue.empty();
     }
 
-private:
+  private:
     std::mutex m_mutex;
     std::queue<T> m_queue;
 };
 
-#endif //HIVE_MIND_BRIDGE_THREADSAFEQUEUE_H
+#endif // HIVE_MIND_BRIDGE_THREADSAFEQUEUE_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/ThreadSafeQueue.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/ThreadSafeQueue.h
@@ -1,0 +1,47 @@
+#ifndef HIVE_MIND_BRIDGE_THREADSAFEQUEUE_H
+#define HIVE_MIND_BRIDGE_THREADSAFEQUEUE_H
+
+#include <queue>
+#include <mutex>
+
+template<class T>
+class ThreadSafeQueue {
+public:
+    ThreadSafeQueue() {}
+
+    void push(const T& item) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_queue.push(item);
+    }
+
+    void pop() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_queue.pop();
+    }
+
+    T front() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_queue.front();
+    }
+
+    T back() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_queue.back();
+    }
+
+    size_t size() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_queue.size();
+    }
+
+    bool empty() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_queue.empty();
+    }
+
+private:
+    std::mutex m_mutex;
+    std::queue<T> m_queue;
+};
+
+#endif //HIVE_MIND_BRIDGE_THREADSAFEQUEUE_H

--- a/src/hive_mind_bridge/include/hive_mind_bridge/ThreadSafeQueue.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/ThreadSafeQueue.h
@@ -3,9 +3,10 @@
 
 #include <mutex>
 #include <queue>
+#include "IThreadSafeQueue.h"
 
 template <class T>
-class ThreadSafeQueue {
+class ThreadSafeQueue : public IThreadSafeQueue<T>{
   public:
     ThreadSafeQueue() {}
 

--- a/src/hive_mind_bridge/include/hive_mind_bridge/ThreadSafeQueue.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/ThreadSafeQueue.h
@@ -1,12 +1,12 @@
 #ifndef HIVE_MIND_BRIDGE_THREADSAFEQUEUE_H
 #define HIVE_MIND_BRIDGE_THREADSAFEQUEUE_H
 
+#include "IThreadSafeQueue.h"
 #include <mutex>
 #include <queue>
-#include "IThreadSafeQueue.h"
 
 template <class T>
-class ThreadSafeQueue : public IThreadSafeQueue<T>{
+class ThreadSafeQueue : public IThreadSafeQueue<T> {
   public:
     ThreadSafeQueue() {}
 

--- a/src/hive_mind_bridge/include/hive_mind_bridge/UserCallbackFunctionWrapper.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/UserCallbackFunctionWrapper.h
@@ -12,7 +12,7 @@ typedef std::array<FunctionCallArgumentDTO,
                    FunctionCallRequestDTO::FUNCTION_CALL_ARGUMENTS_MAX_LENGTH>
     CallbackArgs;
 
-typedef std::function<void(CallbackArgs, int)> CallbackFunction;
+typedef std::function<std::optional<CallbackArgs>(CallbackArgs, int)> CallbackFunction;
 
 typedef std::vector<UserCallbackArgumentDescription> CallbackArgsManifest;
 

--- a/src/hive_mind_bridge/include/hive_mind_bridge/UserCallbackFunctionWrapper.h
+++ b/src/hive_mind_bridge/include/hive_mind_bridge/UserCallbackFunctionWrapper.h
@@ -1,20 +1,12 @@
 #ifndef HIVE_MIND_BRIDGE_USERCALLBACKFUNCTIONWRAPPER_H
 #define HIVE_MIND_BRIDGE_USERCALLBACKFUNCTIONWRAPPER_H
 
-#include "hive_mind_bridge/UserCallbackArgumentDescription.h"
+#include "hive_mind_bridge/Callback.h"
 #include <functional>
 #include <hivemind-host/FunctionCallArgumentDTO.h>
 #include <hivemind-host/FunctionCallRequestDTO.h>
 #include <hivemind-host/FunctionDescriptionArgumentTypeDTO.h>
 #include <unordered_map>
-
-typedef std::array<FunctionCallArgumentDTO,
-                   FunctionCallRequestDTO::FUNCTION_CALL_ARGUMENTS_MAX_LENGTH>
-    CallbackArgs;
-
-typedef std::function<std::optional<CallbackArgs>(CallbackArgs, int)> CallbackFunction;
-
-typedef std::vector<UserCallbackArgumentDescription> CallbackArgsManifest;
 
 class UserCallbackFunctionWrapper {
   public:

--- a/src/hive_mind_bridge/launch/socket_to_move_by_integration_test.launch
+++ b/src/hive_mind_bridge/launch/socket_to_move_by_integration_test.launch
@@ -5,6 +5,7 @@
         <param name="ROBOT_NAME" type="str" value="pioneer_0"/>
     </node>
 
-    <node pkg="hive_mind_bridge" type="SocketToMoveByIntegrationTest" name="hive_mind_bridge_integration_test" output="screen"/>
+    <node pkg="hive_mind_bridge" type="SocketToMoveByIntegrationTest" name="hive_mind_bridge_integration_test"/>
+<!--    todo put output screen here-->
 
 </launch>

--- a/src/hive_mind_bridge/launch/socket_to_move_by_integration_test.launch
+++ b/src/hive_mind_bridge/launch/socket_to_move_by_integration_test.launch
@@ -5,7 +5,6 @@
         <param name="ROBOT_NAME" type="str" value="pioneer_0"/>
     </node>
 
-    <node pkg="hive_mind_bridge" type="SocketToMoveByIntegrationTest" name="hive_mind_bridge_integration_test"/>
-<!--    todo put output screen here-->
+    <node pkg="hive_mind_bridge" type="SocketToMoveByIntegrationTest" name="hive_mind_bridge_integration_test" output="screen"/>
 
 </launch>

--- a/src/hive_mind_bridge/src/HiveMindBridge.cpp
+++ b/src/hive_mind_bridge/src/HiveMindBridge.cpp
@@ -2,7 +2,7 @@
 
 HiveMindBridge::HiveMindBridge(int tcpPort) :
     m_tcpServer(tcpPort), m_deserializer(m_tcpServer), m_serializer(m_tcpServer) {
-    m_bridge = std::make_unique<HiveMindBridgeImpl>(m_tcpServer, m_serializer, m_deserializer);
+    m_bridge = std::make_unique<HiveMindBridgeImpl>(m_tcpServer, m_serializer, m_deserializer, m_inboundQueue);
 }
 
 void HiveMindBridge::spin() { m_bridge->spin(); }

--- a/src/hive_mind_bridge/src/HiveMindBridge.cpp
+++ b/src/hive_mind_bridge/src/HiveMindBridge.cpp
@@ -2,7 +2,8 @@
 
 HiveMindBridge::HiveMindBridge(int tcpPort) :
     m_tcpServer(tcpPort), m_deserializer(m_tcpServer), m_serializer(m_tcpServer) {
-    m_bridge = std::make_unique<HiveMindBridgeImpl>(m_tcpServer, m_serializer, m_deserializer, m_messageHandler, m_inboundQueue);
+    m_bridge = std::make_unique<HiveMindBridgeImpl>(m_tcpServer, m_serializer, m_deserializer,
+                                                    m_messageHandler, m_inboundQueue);
 }
 
 void HiveMindBridge::spin() { m_bridge->spin(); }

--- a/src/hive_mind_bridge/src/HiveMindBridge.cpp
+++ b/src/hive_mind_bridge/src/HiveMindBridge.cpp
@@ -2,7 +2,7 @@
 
 HiveMindBridge::HiveMindBridge(int tcpPort) :
     m_tcpServer(tcpPort), m_deserializer(m_tcpServer), m_serializer(m_tcpServer) {
-    m_bridge = std::make_unique<HiveMindBridgeImpl>(m_tcpServer, m_serializer, m_deserializer, m_inboundQueue);
+    m_bridge = std::make_unique<HiveMindBridgeImpl>(m_tcpServer, m_serializer, m_deserializer, m_messageHandler, m_inboundQueue);
 }
 
 void HiveMindBridge::spin() { m_bridge->spin(); }

--- a/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
+++ b/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
@@ -3,46 +3,55 @@
 HiveMindBridgeImpl::HiveMindBridgeImpl(ITCPServer& tcpServer,
                                        IHiveMindHostSerializer& serializer,
                                        IHiveMindHostDeserializer& deserializer) :
-    m_tcpServer(tcpServer), m_serializer(serializer), m_deserializer(deserializer) {}
+    m_tcpServer(tcpServer), m_serializer(serializer), m_deserializer(deserializer) {
+}
+
+void HiveMindBridgeImpl::inboundThread() {
+    while (isTCPClientConnected()) {
+        MessageDTO message;
+        if (m_deserializer.deserializeFromStream(message)) {
+            m_inboundQueue.push(message);
+        }
+    }
+}
+
+bool HiveMindBridgeImpl::isTCPClientConnected() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_tcpServer.isClientConnected();
+}
 
 void HiveMindBridgeImpl::spin() {
-    if (m_tcpServer.isClientConnected()) {
+    if (isTCPClientConnected()) {
         MessageDTO message;
-        if (m_deserializerFuture.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-
-        } else {
-            m_deserializerFuture = std::async(std::launch::async, m_deserializer.deserializeFromStream, message);
-        }
-        if (m_deserializer.deserializeFromStream(message)) {
+        if (!m_inboundQueue.empty()) {
             // Execute the action
-            result = m_messageHandler.handleMessage(message);
+            result = m_messageHandler.handleMessage(m_inboundQueue.front());
+            m_inboundQueue.pop();
 
             // Send the ack/nack message
             m_serializer.serializeToStream(result.getResponse());
-
-
-        } else {
-            ROS_WARN("The received bytes do not contain a valid message.");
         }
 
         // Check if return values are ready
-        // todo put this in a queue to manage more than one at a time.
-        ROS_INFO("Checking callback status...");
+//        // todo put this in a queue to manage more than one at a time.
+//        ROS_INFO("Checking callback status...");
+//
+//        ROS_WARN("SPIN FUTURE : %d", result.getReturnValues().valid());
+//        std::future_status status = result.getReturnValues().wait_for(std::chrono::microseconds (1));
+//        ROS_INFO("Done.");
+//        if (status == std::future_status::ready) {
+//            // create msg with apropriate request
+//            ROS_INFO("CALLBACK HAS RETURNED");
+//
+//            // send msg.
+//        }
 
-        ROS_WARN("SPIN FUTURE : %d", result.getReturnValues().valid());
-        std::future_status status = result.getReturnValues().wait_for(std::chrono::microseconds (1));
-        ROS_INFO("Done.");
-        if (status == std::future_status::ready) {
-            // create msg with apropriate request
-            ROS_INFO("CALLBACK HAS RETURNED");
-
-            // send msg.
-        }
-
-        ROS_INFO("After expected return");
+//        ROS_INFO("After expected return");
 
     } else {
         m_tcpServer.listen();
+
+        m_inboundThread = std::make_unique<std::thread>(std::thread(&HiveMindBridgeImpl::inboundThread, this));
     }
 }
 

--- a/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
+++ b/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
@@ -3,8 +3,9 @@
 HiveMindBridgeImpl::HiveMindBridgeImpl(ITCPServer& tcpServer,
                                        IHiveMindHostSerializer& serializer,
                                        IHiveMindHostDeserializer& deserializer,
+                                       IMessageHandler& messageHandler,
                                        IThreadSafeQueue<MessageDTO>& queue) :
-    m_tcpServer(tcpServer), m_serializer(serializer), m_deserializer(deserializer), m_inboundQueue(queue) {}
+    m_tcpServer(tcpServer), m_serializer(serializer), m_deserializer(deserializer), m_messageHandler(messageHandler), m_inboundQueue(queue) {}
 
 void HiveMindBridgeImpl::spin() {
     if (isTCPClientConnected()) {

--- a/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
+++ b/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
@@ -10,10 +10,10 @@ void HiveMindBridgeImpl::spin() {
         MessageDTO message;
         if (m_deserializer.deserializeFromStream(message)) {
             // Execute the action
-            MessageDTO responseMessage = m_messageHandler.handleMessage(message);
+            MessageHandlerResult result = m_messageHandler.handleMessage(message);
 
             // Send the ack/nack message
-            m_serializer.serializeToStream(responseMessage);
+            m_serializer.serializeToStream(result.getResponse());
         } else {
             ROS_WARN("The received bytes do not contain a valid message.");
         }

--- a/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
+++ b/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
@@ -5,7 +5,11 @@ HiveMindBridgeImpl::HiveMindBridgeImpl(ITCPServer& tcpServer,
                                        IHiveMindHostDeserializer& deserializer,
                                        IMessageHandler& messageHandler,
                                        IThreadSafeQueue<MessageDTO>& queue) :
-    m_tcpServer(tcpServer), m_serializer(serializer), m_deserializer(deserializer), m_messageHandler(messageHandler), m_inboundQueue(queue) {}
+    m_tcpServer(tcpServer),
+    m_serializer(serializer),
+    m_deserializer(deserializer),
+    m_messageHandler(messageHandler),
+    m_inboundQueue(queue) {}
 
 void HiveMindBridgeImpl::spin() {
     if (isTCPClientConnected()) {

--- a/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
+++ b/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
@@ -83,8 +83,7 @@ void HiveMindBridgeImpl::sendReturn(MessageHandlerResult result) {
         CallbackArgs args = callbackReturnOpt.value().getReturnArgs();
         MessageDTO returnMessage = MessageUtils::createFunctionCallRequest(
             result.getMessageDestinationId(), // swap source and dest since we return to the sender
-            result.getMessageSourceId(),
-            MessageUtils::generateRandomId(),
+            result.getMessageSourceId(), MessageUtils::generateRandomId(),
             result.getSourceModule(), // swap source and dest since we return to the sender
             callbackReturnOpt.value().getReturnFunctionName(), args);
 

--- a/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
+++ b/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
@@ -3,8 +3,7 @@
 HiveMindBridgeImpl::HiveMindBridgeImpl(ITCPServer& tcpServer,
                                        IHiveMindHostSerializer& serializer,
                                        IHiveMindHostDeserializer& deserializer) :
-    m_tcpServer(tcpServer), m_serializer(serializer), m_deserializer(deserializer) {
-}
+    m_tcpServer(tcpServer), m_serializer(serializer), m_deserializer(deserializer) {}
 
 void HiveMindBridgeImpl::spin() {
     if (isTCPClientConnected()) {
@@ -73,12 +72,12 @@ void HiveMindBridgeImpl::sendReturn(MessageHandlerResult result) {
     // Send a return only if there is a return value
     if (argsOpt.has_value()) {
         CallbackArgs args = argsOpt.value();
-        MessageDTO returnMessage = MessageUtils::createFunctionCallRequest(result.getMessageDestinationId(), // swap source and dest since we return to the sender
-                                                result.getMessageSourceId(),
-                                                99, // TODO what should I put here?
-                                                result.getSourceModule(), // swap source and dest since we return to the sender
-                                                result.getReturnCallbackName(),
-                                                args);
+        MessageDTO returnMessage = MessageUtils::createFunctionCallRequest(
+            result.getMessageDestinationId(), // swap source and dest since we return to the sender
+            result.getMessageSourceId(),
+            99, // TODO what should I put here?
+            result.getSourceModule(), // swap source and dest since we return to the sender
+            result.getReturnCallbackName(), args);
 
         m_serializer.serializeToStream(returnMessage);
     } else {

--- a/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
+++ b/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
@@ -84,7 +84,7 @@ void HiveMindBridgeImpl::sendReturn(MessageHandlerResult result) {
         MessageDTO returnMessage = MessageUtils::createFunctionCallRequest(
             result.getMessageDestinationId(), // swap source and dest since we return to the sender
             result.getMessageSourceId(),
-            99, // TODO what should I put here?
+            MessageUtils::generateRandomId(),
             result.getSourceModule(), // swap source and dest since we return to the sender
             callbackReturnOpt.value().getReturnFunctionName(), args);
 

--- a/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
+++ b/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
@@ -2,8 +2,9 @@
 
 HiveMindBridgeImpl::HiveMindBridgeImpl(ITCPServer& tcpServer,
                                        IHiveMindHostSerializer& serializer,
-                                       IHiveMindHostDeserializer& deserializer) :
-    m_tcpServer(tcpServer), m_serializer(serializer), m_deserializer(deserializer) {}
+                                       IHiveMindHostDeserializer& deserializer,
+                                       ThreadSafeQueue<MessageDTO>& queue) :
+    m_tcpServer(tcpServer), m_serializer(serializer), m_deserializer(deserializer), m_inboundQueue(queue) {}
 
 void HiveMindBridgeImpl::spin() {
     if (isTCPClientConnected()) {
@@ -80,7 +81,5 @@ void HiveMindBridgeImpl::sendReturn(MessageHandlerResult result) {
             result.getReturnCallbackName(), args);
 
         m_serializer.serializeToStream(returnMessage);
-    } else {
-        ROS_INFO("NOP");
     }
 }

--- a/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
+++ b/src/hive_mind_bridge/src/HiveMindBridgeImpl.cpp
@@ -3,7 +3,7 @@
 HiveMindBridgeImpl::HiveMindBridgeImpl(ITCPServer& tcpServer,
                                        IHiveMindHostSerializer& serializer,
                                        IHiveMindHostDeserializer& deserializer,
-                                       ThreadSafeQueue<MessageDTO>& queue) :
+                                       IThreadSafeQueue<MessageDTO>& queue) :
     m_tcpServer(tcpServer), m_serializer(serializer), m_deserializer(deserializer), m_inboundQueue(queue) {}
 
 void HiveMindBridgeImpl::spin() {

--- a/src/hive_mind_bridge/src/MessageHandler.cpp
+++ b/src/hive_mind_bridge/src/MessageHandler.cpp
@@ -87,6 +87,10 @@ MessageHandlerResult MessageHandler::handleMessage(MessageDTO message) {
                     std::shared_future<std::optional<CallbackArgs>> ret = std::async(std::launch::async, callback.value(), functionArgs, argsLength).share();
                     result.setFuture(ret);
 
+                    result.setMessageSourceId(msgSourceId);
+                    result.setMessageDestinationId(msgDestinationId);
+                    result.setSourceModule(sourceModule);
+
                     responseStatus = GenericResponseStatusDTO::Ok;
                 } else {
                     responseStatus = GenericResponseStatusDTO::Unknown;

--- a/src/hive_mind_bridge/src/MessageHandler.cpp
+++ b/src/hive_mind_bridge/src/MessageHandler.cpp
@@ -84,9 +84,12 @@ MessageHandlerResult MessageHandler::handleMessage(MessageDTO message) {
 
                 // Call the right callback
                 if (callback) {
-                    std::future<std::optional<CallbackArgs>> ret = std::async(callback.value(), functionArgs, argsLength);
+                    std::shared_future<std::optional<CallbackArgs>> ret = std::async(std::launch::async, callback.value(), functionArgs, argsLength).share();
 
-                    result.setReturnValues(std::move(ret));
+//                    result.setReturnValues(std::move(ret));
+                    result.setReturnValues(ret);
+
+                    ROS_WARN("ORIGINAL FUTURE : %d", ret.valid());
 
                     responseStatus = GenericResponseStatusDTO::Ok;
                 } else {
@@ -110,11 +113,6 @@ MessageHandlerResult MessageHandler::handleMessage(MessageDTO message) {
             }
         }
     }
-// todo do something with this
-//    if (responseStatus != GenericResponseStatusDTO::Ok) {
-//        ROS_WARN("Message handling failed");
-//    }
-
     return result;
 }
 

--- a/src/hive_mind_bridge/src/MessageHandler.cpp
+++ b/src/hive_mind_bridge/src/MessageHandler.cpp
@@ -1,5 +1,5 @@
-#include <future>
 #include "hive_mind_bridge/MessageHandler.h"
+#include <future>
 
 MessageHandler::MessageHandler() {}
 
@@ -84,9 +84,11 @@ MessageHandlerResult MessageHandler::handleMessage(MessageDTO message) {
 
                 // Call the right callback
                 if (callback) {
-                    std::shared_future<std::optional<CallbackArgs>> ret = std::async(std::launch::async, callback.value(), functionArgs, argsLength).share();
+                    std::shared_future<std::optional<CallbackArgs>> ret =
+                        std::async(std::launch::async, callback.value(), functionArgs, argsLength)
+                            .share();
                     result.setFuture(ret);
-
+                    result.setCallbackName(functionName);
                     result.setMessageSourceId(msgSourceId);
                     result.setMessageDestinationId(msgDestinationId);
                     result.setSourceModule(sourceModule);
@@ -98,18 +100,18 @@ MessageHandlerResult MessageHandler::handleMessage(MessageDTO message) {
                              functionName.c_str());
                 }
 
-                result.setResponse(MessageUtils::createResponseMessage(requestId, msgDestinationId, msgSourceId,
-                                                                       sourceModule, responseStatus, ""));
+                result.setResponse(MessageUtils::createResponseMessage(
+                    requestId, msgDestinationId, msgSourceId, sourceModule, responseStatus, ""));
 
                 // FunctionListLengthRequest
             } else if (std::holds_alternative<FunctionListLengthRequestDTO>(functionCallRequest)) {
-                result.setResponse(handleFunctionListLengthRequest(requestId, msgDestinationId, msgSourceId,
-                                                                   sourceModule));
+                result.setResponse(handleFunctionListLengthRequest(requestId, msgDestinationId,
+                                                                   msgSourceId, sourceModule));
                 // FunctionDescriptionRequest
             } else if (std::holds_alternative<FunctionDescriptionRequestDTO>(functionCallRequest)) {
                 result.setResponse(handleFunctionDescriptionRequest(
-                        requestId, msgDestinationId, msgSourceId, sourceModule,
-                        std::get<FunctionDescriptionRequestDTO>(functionCallRequest)));
+                    requestId, msgDestinationId, msgSourceId, sourceModule,
+                    std::get<FunctionDescriptionRequestDTO>(functionCallRequest)));
             }
         }
     }

--- a/src/hive_mind_bridge/src/MessageHandler.cpp
+++ b/src/hive_mind_bridge/src/MessageHandler.cpp
@@ -85,11 +85,7 @@ MessageHandlerResult MessageHandler::handleMessage(MessageDTO message) {
                 // Call the right callback
                 if (callback) {
                     std::shared_future<std::optional<CallbackArgs>> ret = std::async(std::launch::async, callback.value(), functionArgs, argsLength).share();
-
-//                    result.setReturnValues(std::move(ret));
-                    result.setReturnValues(ret);
-
-                    ROS_WARN("ORIGINAL FUTURE : %d", ret.valid());
+                    result.setFuture(ret);
 
                     responseStatus = GenericResponseStatusDTO::Ok;
                 } else {

--- a/src/hive_mind_bridge/src/MessageHandler.cpp
+++ b/src/hive_mind_bridge/src/MessageHandler.cpp
@@ -1,3 +1,4 @@
+#include <future>
 #include "hive_mind_bridge/MessageHandler.h"
 
 MessageHandler::MessageHandler() {}
@@ -81,7 +82,7 @@ MessageDTO MessageHandler::handleMessage(MessageDTO message) {
 
                 // Call the right callback
                 if (callback) {
-                    callback.value()(functionArgs, argsLength);
+                    std::async(callback.value(), functionArgs, argsLength);
                     responseStatus = GenericResponseStatusDTO::Ok;
                 } else {
                     responseStatus = GenericResponseStatusDTO::Unknown;

--- a/src/hive_mind_bridge/src/MessageHandlerResult.cpp
+++ b/src/hive_mind_bridge/src/MessageHandlerResult.cpp
@@ -15,3 +15,31 @@ MessageDTO MessageHandlerResult::getResponse() {
 std::shared_future<std::optional<CallbackArgs>> MessageHandlerResult::getFuture() {
     return m_future;
 }
+
+std::string MessageHandlerResult::getReturnCallbackName() {
+    return m_callbackName + "Return";
+}
+
+void MessageHandlerResult::setMessageSourceId(uint32_t id) {
+    m_msgSourceId = id;
+}
+
+void MessageHandlerResult::setMessageDestinationId(uint32_t id) {
+    m_msgDestinationId = id;
+}
+
+void MessageHandlerResult::setSourceModule(UserCallTargetDTO target) {
+    m_sourceModule = target;
+}
+
+uint32_t MessageHandlerResult::getMessageSourceId() {
+    return m_msgSourceId;
+}
+
+uint32_t MessageHandlerResult::getMessageDestinationId() {
+    return m_msgDestinationId;
+}
+
+UserCallTargetDTO MessageHandlerResult::getSourceModule() {
+    return m_sourceModule;
+}

--- a/src/hive_mind_bridge/src/MessageHandlerResult.cpp
+++ b/src/hive_mind_bridge/src/MessageHandlerResult.cpp
@@ -4,16 +4,14 @@ void MessageHandlerResult::setResponse(MessageDTO message) {
     m_responseMessage = message;
 }
 
-void MessageHandlerResult::setReturnValues(std::shared_future<std::optional<CallbackArgs>> returnValues) {
-//    m_returnValues = std::move(returnValues);
-    m_returnValues = returnValues;
+void MessageHandlerResult::setFuture(std::shared_future<std::optional<CallbackArgs>> future) {
+    m_future = future;
 }
 
 MessageDTO MessageHandlerResult::getResponse() {
     return m_responseMessage;
 }
 
-std::shared_future<std::optional<CallbackArgs>> MessageHandlerResult::getReturnValues() {
-//    return std::move(m_returnValues);
-    return m_returnValues;
+std::shared_future<std::optional<CallbackArgs>> MessageHandlerResult::getFuture() {
+    return m_future;
 }

--- a/src/hive_mind_bridge/src/MessageHandlerResult.cpp
+++ b/src/hive_mind_bridge/src/MessageHandlerResult.cpp
@@ -1,0 +1,17 @@
+#include "hive_mind_bridge/MessageHandlerResult.h"
+
+void MessageHandlerResult::setResponse(MessageDTO message) {
+    m_responseMessage = message;
+}
+
+void MessageHandlerResult::setReturnValues(std::future<std::optional<CallbackArgs>> returnValues) {
+    m_returnValues = std::move(returnValues);
+}
+
+MessageDTO MessageHandlerResult::getResponse() {
+    return m_responseMessage;
+}
+
+std::future<std::optional<CallbackArgs>> MessageHandlerResult::getReturnValues() {
+    return std::move(m_returnValues);
+}

--- a/src/hive_mind_bridge/src/MessageHandlerResult.cpp
+++ b/src/hive_mind_bridge/src/MessageHandlerResult.cpp
@@ -4,14 +4,16 @@ void MessageHandlerResult::setResponse(MessageDTO message) {
     m_responseMessage = message;
 }
 
-void MessageHandlerResult::setReturnValues(std::future<std::optional<CallbackArgs>> returnValues) {
-    m_returnValues = std::move(returnValues);
+void MessageHandlerResult::setReturnValues(std::shared_future<std::optional<CallbackArgs>> returnValues) {
+//    m_returnValues = std::move(returnValues);
+    m_returnValues = returnValues;
 }
 
 MessageDTO MessageHandlerResult::getResponse() {
     return m_responseMessage;
 }
 
-std::future<std::optional<CallbackArgs>> MessageHandlerResult::getReturnValues() {
-    return std::move(m_returnValues);
+std::shared_future<std::optional<CallbackArgs>> MessageHandlerResult::getReturnValues() {
+//    return std::move(m_returnValues);
+    return m_returnValues;
 }

--- a/src/hive_mind_bridge/src/MessageHandlerResult.cpp
+++ b/src/hive_mind_bridge/src/MessageHandlerResult.cpp
@@ -2,19 +2,18 @@
 
 void MessageHandlerResult::setResponse(MessageDTO message) { m_responseMessage = message; }
 
-void MessageHandlerResult::setFuture(std::shared_future<std::optional<CallbackArgs>> future) {
-    m_future = future;
+void MessageHandlerResult::setCallbackReturnContext(
+    std::shared_future<std::optional<CallbackReturn>> future) {
+    m_callbackReturnContext = future;
 }
 
 MessageDTO MessageHandlerResult::getResponse() { return m_responseMessage; }
 
-std::shared_future<std::optional<CallbackArgs>> MessageHandlerResult::getFuture() {
-    return m_future;
+std::shared_future<std::optional<CallbackReturn>> MessageHandlerResult::getCallbackReturnContext() {
+    return m_callbackReturnContext;
 }
 
 void MessageHandlerResult::setCallbackName(std::string name) { m_callbackName = name; }
-
-std::string MessageHandlerResult::getReturnCallbackName() { return m_callbackName + "Return"; }
 
 void MessageHandlerResult::setMessageSourceId(uint32_t id) { m_msgSourceId = id; }
 

--- a/src/hive_mind_bridge/src/MessageHandlerResult.cpp
+++ b/src/hive_mind_bridge/src/MessageHandlerResult.cpp
@@ -12,9 +12,7 @@ std::shared_future<std::optional<CallbackArgs>> MessageHandlerResult::getFuture(
     return m_future;
 }
 
-void MessageHandlerResult::setCallbackName(std::string name) {
-    m_callbackName = name;
-}
+void MessageHandlerResult::setCallbackName(std::string name) { m_callbackName = name; }
 
 std::string MessageHandlerResult::getReturnCallbackName() { return m_callbackName + "Return"; }
 

--- a/src/hive_mind_bridge/src/MessageHandlerResult.cpp
+++ b/src/hive_mind_bridge/src/MessageHandlerResult.cpp
@@ -1,45 +1,31 @@
 #include "hive_mind_bridge/MessageHandlerResult.h"
 
-void MessageHandlerResult::setResponse(MessageDTO message) {
-    m_responseMessage = message;
-}
+void MessageHandlerResult::setResponse(MessageDTO message) { m_responseMessage = message; }
 
 void MessageHandlerResult::setFuture(std::shared_future<std::optional<CallbackArgs>> future) {
     m_future = future;
 }
 
-MessageDTO MessageHandlerResult::getResponse() {
-    return m_responseMessage;
-}
+MessageDTO MessageHandlerResult::getResponse() { return m_responseMessage; }
 
 std::shared_future<std::optional<CallbackArgs>> MessageHandlerResult::getFuture() {
     return m_future;
 }
 
-std::string MessageHandlerResult::getReturnCallbackName() {
-    return m_callbackName + "Return";
+void MessageHandlerResult::setCallbackName(std::string name) {
+    m_callbackName = name;
 }
 
-void MessageHandlerResult::setMessageSourceId(uint32_t id) {
-    m_msgSourceId = id;
-}
+std::string MessageHandlerResult::getReturnCallbackName() { return m_callbackName + "Return"; }
 
-void MessageHandlerResult::setMessageDestinationId(uint32_t id) {
-    m_msgDestinationId = id;
-}
+void MessageHandlerResult::setMessageSourceId(uint32_t id) { m_msgSourceId = id; }
 
-void MessageHandlerResult::setSourceModule(UserCallTargetDTO target) {
-    m_sourceModule = target;
-}
+void MessageHandlerResult::setMessageDestinationId(uint32_t id) { m_msgDestinationId = id; }
 
-uint32_t MessageHandlerResult::getMessageSourceId() {
-    return m_msgSourceId;
-}
+void MessageHandlerResult::setSourceModule(UserCallTargetDTO target) { m_sourceModule = target; }
 
-uint32_t MessageHandlerResult::getMessageDestinationId() {
-    return m_msgDestinationId;
-}
+uint32_t MessageHandlerResult::getMessageSourceId() { return m_msgSourceId; }
 
-UserCallTargetDTO MessageHandlerResult::getSourceModule() {
-    return m_sourceModule;
-}
+uint32_t MessageHandlerResult::getMessageDestinationId() { return m_msgDestinationId; }
+
+UserCallTargetDTO MessageHandlerResult::getSourceModule() { return m_sourceModule; }

--- a/src/hive_mind_bridge/src/MessageUtils.cpp
+++ b/src/hive_mind_bridge/src/MessageUtils.cpp
@@ -47,21 +47,29 @@ MessageDTO MessageUtils::createFunctionDescriptionResponseMessage(
     return responseMessage;
 }
 
-uint8_t MessageUtils::createFunctionCallArguments(CallbackArgs args, FunctionCallArgumentDTO* functionCallArgument) {
-    functionCallArgument = args.data();
-    return args.size();
+MessageDTO MessageUtils::createFunctionCallRequest(uint32_t msgSourceId,
+                                                   uint32_t msgDestinationId,
+                                                   uint32_t requestId,
+                                                   UserCallTargetDTO moduleDestination,
+                                                   std::string callbackName,
+                                                   CallbackArgs args) {
+    FunctionCallRequestDTO functionCallRequest(callbackName.c_str(), args.data(), args.size());
+
+    UserCallRequestDTO userCallRequest(UserCallTargetDTO::HOST, moduleDestination,
+                                       functionCallRequest);
+    RequestDTO RequestDTO(1, userCallRequest);
+    MessageDTO message(1, 2, RequestDTO);
+
+    return message;
 }
 
 MessageDTO MessageUtils::createFunctionCallRequest(uint32_t msgSourceId,
-                                     uint32_t msgDestinationId,
-                                     uint32_t requestId,
-                                     UserCallTargetDTO moduleDestination,
-                                     std::string callbackName,
-                                     CallbackArgs args) {
-    FunctionCallArgumentDTO *functionCallArgument;
-    uint8_t size = createFunctionCallArguments(args, functionCallArgument);
+                                                   uint32_t msgDestinationId,
+                                                   uint32_t requestId,
+                                                   UserCallTargetDTO moduleDestination,
+                                                   std::string callbackName) {
 
-    FunctionCallRequestDTO functionCallRequest(callbackName.c_str(), functionCallArgument, size);
+    FunctionCallRequestDTO functionCallRequest(callbackName.c_str(), nullptr, 0);
 
     UserCallRequestDTO userCallRequest(UserCallTargetDTO::HOST, moduleDestination,
                                        functionCallRequest);

--- a/src/hive_mind_bridge/src/MessageUtils.cpp
+++ b/src/hive_mind_bridge/src/MessageUtils.cpp
@@ -46,3 +46,27 @@ MessageDTO MessageUtils::createFunctionDescriptionResponseMessage(
 
     return responseMessage;
 }
+
+uint8_t MessageUtils::createFunctionCallArguments(CallbackArgs args, FunctionCallArgumentDTO* functionCallArgument) {
+    functionCallArgument = args.data();
+    return args.size();
+}
+
+MessageDTO MessageUtils::createFunctionCallRequest(uint32_t msgSourceId,
+                                     uint32_t msgDestinationId,
+                                     uint32_t requestId,
+                                     UserCallTargetDTO moduleDestination,
+                                     std::string callbackName,
+                                     CallbackArgs args) {
+    FunctionCallArgumentDTO *functionCallArgument;
+    uint8_t size = createFunctionCallArguments(args, functionCallArgument);
+
+    FunctionCallRequestDTO functionCallRequest(callbackName.c_str(), functionCallArgument, size);
+
+    UserCallRequestDTO userCallRequest(UserCallTargetDTO::HOST, moduleDestination,
+                                       functionCallRequest);
+    RequestDTO RequestDTO(1, userCallRequest);
+    MessageDTO message(1, 2, RequestDTO);
+
+    return message;
+}

--- a/src/hive_mind_bridge/src/MessageUtils.cpp
+++ b/src/hive_mind_bridge/src/MessageUtils.cpp
@@ -78,3 +78,7 @@ MessageDTO MessageUtils::createFunctionCallRequest(uint32_t msgSourceId,
 
     return message;
 }
+
+uint32_t MessageUtils::generateRandomId() {
+    return rand() % UINT32_MAX;
+}

--- a/src/hive_mind_bridge/src/MessageUtils.cpp
+++ b/src/hive_mind_bridge/src/MessageUtils.cpp
@@ -79,6 +79,4 @@ MessageDTO MessageUtils::createFunctionCallRequest(uint32_t msgSourceId,
     return message;
 }
 
-uint32_t MessageUtils::generateRandomId() {
-    return rand() % UINT32_MAX;
-}
+uint32_t MessageUtils::generateRandomId() { return rand() % UINT32_MAX; }

--- a/src/hive_mind_bridge/src/MessageUtils.cpp
+++ b/src/hive_mind_bridge/src/MessageUtils.cpp
@@ -57,8 +57,8 @@ MessageDTO MessageUtils::createFunctionCallRequest(uint32_t msgSourceId,
 
     UserCallRequestDTO userCallRequest(UserCallTargetDTO::HOST, moduleDestination,
                                        functionCallRequest);
-    RequestDTO RequestDTO(1, userCallRequest);
-    MessageDTO message(1, 2, RequestDTO);
+    RequestDTO RequestDTO(requestId, userCallRequest);
+    MessageDTO message(msgSourceId, msgDestinationId, RequestDTO);
 
     return message;
 }
@@ -73,8 +73,8 @@ MessageDTO MessageUtils::createFunctionCallRequest(uint32_t msgSourceId,
 
     UserCallRequestDTO userCallRequest(UserCallTargetDTO::HOST, moduleDestination,
                                        functionCallRequest);
-    RequestDTO RequestDTO(1, userCallRequest);
-    MessageDTO message(1, 2, RequestDTO);
+    RequestDTO RequestDTO(requestId, userCallRequest);
+    MessageDTO message(msgSourceId, msgDestinationId, RequestDTO);
 
     return message;
 }

--- a/src/hive_mind_bridge/src/main.cpp
+++ b/src/hive_mind_bridge/src/main.cpp
@@ -22,7 +22,8 @@ int main(int argc, char** argv) {
     HiveMindBridge bridge(port);
 
     // Register custom actions
-    CallbackFunction moveByCallback = [&](CallbackArgs args, int argsLength) -> CallbackArgs {
+    CallbackFunction moveByCallback = [&](CallbackArgs args,
+                                          int argsLength) -> std::optional<CallbackArgs> {
         swarmus_ros_navigation::MoveByMessage moveByMessage;
 
         moveByMessage.distance_x = std::get<float>(args[0].getArgument());
@@ -31,7 +32,7 @@ int main(int argc, char** argv) {
         // Publish on moveby
         moveByPublisher.publish(moveByMessage);
 
-        std::this_thread::sleep_for(std::chrono::seconds (2));
+        std::this_thread::sleep_for(std::chrono::seconds(2));
 
         ROS_INFO("CALLBACK WILL RETURN JUST NOW");
 
@@ -45,30 +46,18 @@ int main(int argc, char** argv) {
         UserCallbackArgumentDescription("y", FunctionDescriptionArgumentTypeDTO::Float));
     bridge.registerCustomAction("moveBy", moveByCallback, moveByManifest);
 
-    CallbackFunction getPosition = [&](CallbackArgs args, int argsLength) -> CallbackArgs  {
-        // Go get the values elsewhere...
-        int64_t x = 1;
-        float y = 2.0;
+    CallbackFunction getStatus = [&](CallbackArgs args,
+                                     int argsLength) -> std::optional<CallbackArgs> {
+        // todo This remains to be implemented.
+        int64_t isRobotOk = 1;
 
         CallbackArgs returnArgs;
-        returnArgs[1] = FunctionCallArgumentDTO(x);
-        returnArgs[2] = FunctionCallArgumentDTO(y);
+        returnArgs[0] = FunctionCallArgumentDTO(isRobotOk);
 
+        ROS_INFO("RETURNING FROM GET STATUS");
         return returnArgs;
     };
-    bridge.registerCustomAction("getPosition", getPosition);
-
-    CallbackFunction getPositionReturn = [&](CallbackArgs args, int argsLength) -> CallbackArgs  {
-        // What to do when we receive a position.
-        ROS_INFO("RECEIVED A POSITION: (%d, %f)", std::get<int64_t>(args[0].getArgument()), std::get<float>(args[1].getArgument()));
-
-        return {};
-    };
-
-    CallbackArgsManifest  getPositionReturnManifest;
-    getPositionReturnManifest.push_back(UserCallbackArgumentDescription("x", FunctionDescriptionArgumentTypeDTO::Int));
-    getPositionReturnManifest.push_back(UserCallbackArgumentDescription("y", FunctionDescriptionArgumentTypeDTO::Float));
-    bridge.registerCustomAction("getPositionReturn", getPositionReturn, getPositionReturnManifest);
+    bridge.registerCustomAction("getStatus", getStatus);
 
     // Register event hooks
     bridge.onConnect([]() { ROS_INFO("Client connected."); });

--- a/src/hive_mind_bridge/src/main.cpp
+++ b/src/hive_mind_bridge/src/main.cpp
@@ -32,7 +32,8 @@ int main(int argc, char** argv) {
         // Publish on moveby
         moveByPublisher.publish(moveByMessage);
 
-        std::this_thread::sleep_for(std::chrono::seconds(2));
+        std::this_thread::sleep_for(
+            std::chrono::seconds(2)); // Just to show that callbacks can be blocking
 
         return {};
     };

--- a/src/hive_mind_bridge/src/main.cpp
+++ b/src/hive_mind_bridge/src/main.cpp
@@ -22,7 +22,7 @@ int main(int argc, char** argv) {
     HiveMindBridge bridge(port);
 
     // Register custom actions
-    CallbackFunction moveByCallback = [&](CallbackArgs args, int argsLength) {
+    CallbackFunction moveByCallback = [&](CallbackArgs args, int argsLength) -> CallbackArgs {
         swarmus_ros_navigation::MoveByMessage moveByMessage;
 
         moveByMessage.distance_x = std::get<float>(args[0].getArgument());
@@ -30,6 +30,8 @@ int main(int argc, char** argv) {
 
         // Publish on moveby
         moveByPublisher.publish(moveByMessage);
+
+        return {};
     };
 
     CallbackArgsManifest moveByManifest;
@@ -38,6 +40,31 @@ int main(int argc, char** argv) {
     moveByManifest.push_back(
         UserCallbackArgumentDescription("y", FunctionDescriptionArgumentTypeDTO::Float));
     bridge.registerCustomAction("moveBy", moveByCallback, moveByManifest);
+
+    CallbackFunction getPosition = [&](CallbackArgs args, int argsLength) -> CallbackArgs  {
+        // Go get the values elsewhere...
+        int64_t x = 1;
+        float y = 2.0;
+
+        CallbackArgs returnArgs;
+        returnArgs[1] = FunctionCallArgumentDTO(x);
+        returnArgs[2] = FunctionCallArgumentDTO(y);
+
+        return returnArgs;
+    };
+    bridge.registerCustomAction("getPosition", getPosition);
+
+    CallbackFunction getPositionReturn = [&](CallbackArgs args, int argsLength) -> CallbackArgs  {
+        // What to do when we receive a position.
+        ROS_INFO("RECEIVED A POSITION: (%d, %f)", std::get<int64_t>(args[0].getArgument()), std::get<float>(args[1].getArgument()));
+
+        return {};
+    };
+
+    CallbackArgsManifest  getPositionReturnManifest;
+    getPositionReturnManifest.push_back(UserCallbackArgumentDescription("x", FunctionDescriptionArgumentTypeDTO::Int));
+    getPositionReturnManifest.push_back(UserCallbackArgumentDescription("y", FunctionDescriptionArgumentTypeDTO::Float));
+    bridge.registerCustomAction("getPositionReturn", getPositionReturn, getPositionReturnManifest);
 
     // Register event hooks
     bridge.onConnect([]() { ROS_INFO("Client connected."); });

--- a/src/hive_mind_bridge/src/main.cpp
+++ b/src/hive_mind_bridge/src/main.cpp
@@ -5,7 +5,7 @@
 #include <hivemind-host/FunctionCallArgumentDTO.h>
 #include <optional>
 
-constexpr uint8_t RATE_HZ{2};
+constexpr uint8_t RATE_HZ{10};
 constexpr uint32_t compoundId{1}; // TODO find a way for the HiveMind and the robot to share this ID
 
 int main(int argc, char** argv) {
@@ -30,6 +30,10 @@ int main(int argc, char** argv) {
 
         // Publish on moveby
         moveByPublisher.publish(moveByMessage);
+
+        std::this_thread::sleep_for(std::chrono::seconds (2));
+
+        ROS_INFO("CALLBACK WILL RETURN JUST NOW");
 
         return {};
     };

--- a/src/hive_mind_bridge/src/main.cpp
+++ b/src/hive_mind_bridge/src/main.cpp
@@ -1,3 +1,4 @@
+#include "hive_mind_bridge/Callback.h"
 #include "hive_mind_bridge/HiveMindBridge.h"
 #include "hive_mind_bridge/MessageHandler.h"
 #include "ros/ros.h"
@@ -23,7 +24,7 @@ int main(int argc, char** argv) {
 
     // Register custom actions
     CallbackFunction moveByCallback = [&](CallbackArgs args,
-                                          int argsLength) -> std::optional<CallbackArgs> {
+                                          int argsLength) -> std::optional<CallbackReturn> {
         swarmus_ros_navigation::MoveByMessage moveByMessage;
 
         moveByMessage.distance_x = std::get<float>(args[0].getArgument());
@@ -46,14 +47,16 @@ int main(int argc, char** argv) {
     bridge.registerCustomAction("moveBy", moveByCallback, moveByManifest);
 
     CallbackFunction getStatus = [&](CallbackArgs args,
-                                     int argsLength) -> std::optional<CallbackArgs> {
+                                     int argsLength) -> std::optional<CallbackReturn> {
         // todo This remains to be implemented.
         int64_t isRobotOk = 1;
 
         CallbackArgs returnArgs;
         returnArgs[0] = FunctionCallArgumentDTO(isRobotOk);
 
-        return returnArgs;
+        CallbackReturn cbReturn("getStatusReturn", returnArgs);
+
+        return cbReturn;
     };
     bridge.registerCustomAction("getStatus", getStatus);
 

--- a/src/hive_mind_bridge/src/main.cpp
+++ b/src/hive_mind_bridge/src/main.cpp
@@ -34,8 +34,6 @@ int main(int argc, char** argv) {
 
         std::this_thread::sleep_for(std::chrono::seconds(2));
 
-        ROS_INFO("CALLBACK WILL RETURN JUST NOW");
-
         return {};
     };
 
@@ -54,7 +52,6 @@ int main(int argc, char** argv) {
         CallbackArgs returnArgs;
         returnArgs[0] = FunctionCallArgumentDTO(isRobotOk);
 
-        ROS_INFO("RETURNING FROM GET STATUS");
         return returnArgs;
     };
     bridge.registerCustomAction("getStatus", getStatus);

--- a/src/hive_mind_bridge/test/HiveMindBridgeImplUnitTest.cpp
+++ b/src/hive_mind_bridge/test/HiveMindBridgeImplUnitTest.cpp
@@ -2,6 +2,7 @@
 #include "mocks/HiveMindHostDeserializerInterfaceMock.h"
 #include "mocks/HiveMindHostSerializerInterfaceMock.h"
 #include "mocks/TCPServerInterfaceMock.h"
+#include "mocks/ThreadSafeQueueInterfaceMock.h"
 #include <gmock/gmock.h>
 
 class HiveMindBridgeImplUnitFixture : public testing::Test {
@@ -10,10 +11,10 @@ class HiveMindBridgeImplUnitFixture : public testing::Test {
     HiveMindHostDeserializerInterfaceMock m_deserializer;
     HiveMindHostSerializerInterfaceMock m_serializer;
     HiveMindBridgeImpl* m_hivemindBridge;
-    ThreadSafeQueue<MessageDTO> queue;
+    ThreadSafeQueueInterfaceMock<MessageDTO> m_queue;
 
     void SetUp() {
-        m_hivemindBridge = new HiveMindBridgeImpl(m_tcpServer, m_serializer, m_deserializer, queue);
+        m_hivemindBridge = new HiveMindBridgeImpl(m_tcpServer, m_serializer, m_deserializer, m_queue);
     }
 
     void TearDown() { delete m_hivemindBridge; }
@@ -21,7 +22,9 @@ class HiveMindBridgeImplUnitFixture : public testing::Test {
 
 TEST_F(HiveMindBridgeImplUnitFixture, spinReceiveValidMessage) {
     EXPECT_CALL(m_tcpServer, isClientConnected()).WillOnce(testing::Return(true));
-    EXPECT_CALL(m_deserializer, deserializeFromStream(testing::_)).WillOnce(testing::Return(true));
+    EXPECT_CALL(m_queue, empty()).WillOnce(testing::Return(false));
+    EXPECT_CALL(m_queue, front());
+    EXPECT_CALL(m_queue, pop());
     EXPECT_CALL(m_serializer, serializeToStream(testing::_));
 
     m_hivemindBridge->spin();
@@ -34,9 +37,9 @@ TEST_F(HiveMindBridgeImplUnitFixture, spinReceiveNoMessage) {
     m_hivemindBridge->spin();
 }
 
-TEST_F(HiveMindBridgeImplUnitFixture, spinClientDisconnected) {
-    EXPECT_CALL(m_tcpServer, isClientConnected()).WillOnce(testing::Return(false));
-    EXPECT_CALL(m_tcpServer, listen());
-
-    m_hivemindBridge->spin();
-}
+//TEST_F(HiveMindBridgeImplUnitFixture, spinClientDisconnected) {
+//    EXPECT_CALL(m_tcpServer, isClientConnected()).WillOnce(testing::Return(false));
+//    EXPECT_CALL(m_tcpServer, listen());
+//
+//    m_hivemindBridge->spin();
+//}

--- a/src/hive_mind_bridge/test/HiveMindBridgeImplUnitTest.cpp
+++ b/src/hive_mind_bridge/test/HiveMindBridgeImplUnitTest.cpp
@@ -10,9 +10,10 @@ class HiveMindBridgeImplUnitFixture : public testing::Test {
     HiveMindHostDeserializerInterfaceMock m_deserializer;
     HiveMindHostSerializerInterfaceMock m_serializer;
     HiveMindBridgeImpl* m_hivemindBridge;
+    ThreadSafeQueue<MessageDTO> queue;
 
     void SetUp() {
-        m_hivemindBridge = new HiveMindBridgeImpl(m_tcpServer, m_serializer, m_deserializer);
+        m_hivemindBridge = new HiveMindBridgeImpl(m_tcpServer, m_serializer, m_deserializer, queue);
     }
 
     void TearDown() { delete m_hivemindBridge; }

--- a/src/hive_mind_bridge/test/HiveMindBridgeImplUnitTest.cpp
+++ b/src/hive_mind_bridge/test/HiveMindBridgeImplUnitTest.cpp
@@ -6,16 +6,16 @@
 #include "mocks/ThreadSafeQueueInterfaceMock.h"
 #include <gmock/gmock.h>
 
-std::function<std::optional<CallbackArgs>()> validCallbackWithInstantReturn = []() -> std::optional<CallbackArgs> {
+std::function<std::optional<CallbackArgs>()> validCallbackWithInstantReturn =
+    []() -> std::optional<CallbackArgs> {
     CallbackArgs returnArgs;
     returnArgs[0] = FunctionCallArgumentDTO(1.0f);
 
     return returnArgs;
 };
 
-std::function<std::optional<CallbackArgs>()> validCallbackWithoutInstantReturn = []() -> std::optional<CallbackArgs> {
-    return {};
-};
+std::function<std::optional<CallbackArgs>()> validCallbackWithoutInstantReturn =
+    []() -> std::optional<CallbackArgs> { return {}; };
 
 class HiveMindBridgeImplUnitFixture : public testing::Test {
   protected:
@@ -27,11 +27,12 @@ class HiveMindBridgeImplUnitFixture : public testing::Test {
     MessageHandlerInterfaceMock m_messageHandler;
 
     MessageHandlerResult validResultWithReturn;
-    MessageDTO dummyResponseMessage = MessageUtils::createResponseMessage(1,1,1,UserCallTargetDTO::UNKNOWN,GenericResponseStatusDTO::Ok,"");
+    MessageDTO dummyResponseMessage = MessageUtils::createResponseMessage(
+        1, 1, 1, UserCallTargetDTO::UNKNOWN, GenericResponseStatusDTO::Ok, "");
 
     void SetUp() {
-        m_hivemindBridge = new HiveMindBridgeImpl(m_tcpServer, m_serializer, m_deserializer, m_messageHandler, m_queue);
-
+        m_hivemindBridge = new HiveMindBridgeImpl(m_tcpServer, m_serializer, m_deserializer,
+                                                  m_messageHandler, m_queue);
     }
 
     void TearDown() { delete m_hivemindBridge; }
@@ -39,15 +40,18 @@ class HiveMindBridgeImplUnitFixture : public testing::Test {
 
 TEST_F(HiveMindBridgeImplUnitFixture, spinInstantaneousCallback_WithReturn) {
     // Given
-    validResultWithReturn.setFuture(std::async(std::launch::async, validCallbackWithInstantReturn).share());
+    validResultWithReturn.setFuture(
+        std::async(std::launch::async, validCallbackWithInstantReturn).share());
     validResultWithReturn.setResponse(dummyResponseMessage);
-    std::this_thread::sleep_for(std::chrono::milliseconds(250)); // Just to make sure the callback ends before test
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(250)); // Just to make sure the callback ends before test
 
     // When
     EXPECT_CALL(m_tcpServer, isClientConnected()).WillOnce(testing::Return(true));
     EXPECT_CALL(m_queue, empty()).WillOnce(testing::Return(false));
     EXPECT_CALL(m_queue, front());
-    EXPECT_CALL(m_messageHandler, handleMessage(testing::_)).WillOnce(testing::Return(validResultWithReturn));
+    EXPECT_CALL(m_messageHandler, handleMessage(testing::_))
+        .WillOnce(testing::Return(validResultWithReturn));
     EXPECT_CALL(m_queue, pop());
     EXPECT_CALL(m_serializer, serializeToStream(testing::_)).Times(2); // ack + return
 
@@ -58,15 +62,18 @@ TEST_F(HiveMindBridgeImplUnitFixture, spinInstantaneousCallback_WithReturn) {
 
 TEST_F(HiveMindBridgeImplUnitFixture, spinInstantaneousCallback_WithoutReturn) {
     // Given
-    validResultWithReturn.setFuture(std::async(std::launch::async, validCallbackWithoutInstantReturn).share());
+    validResultWithReturn.setFuture(
+        std::async(std::launch::async, validCallbackWithoutInstantReturn).share());
     validResultWithReturn.setResponse(dummyResponseMessage);
-    std::this_thread::sleep_for(std::chrono::milliseconds(250)); // Just to make sure the callback ends before test
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(250)); // Just to make sure the callback ends before test
 
     // When
     EXPECT_CALL(m_tcpServer, isClientConnected()).WillOnce(testing::Return(true));
     EXPECT_CALL(m_queue, empty()).WillOnce(testing::Return(false));
     EXPECT_CALL(m_queue, front());
-    EXPECT_CALL(m_messageHandler, handleMessage(testing::_)).WillOnce(testing::Return(validResultWithReturn));
+    EXPECT_CALL(m_messageHandler, handleMessage(testing::_))
+        .WillOnce(testing::Return(validResultWithReturn));
     EXPECT_CALL(m_queue, pop());
     EXPECT_CALL(m_serializer, serializeToStream(testing::_)).Times(1); // ack only
 

--- a/src/hive_mind_bridge/test/HiveMindBridgeImplUnitTest.cpp
+++ b/src/hive_mind_bridge/test/HiveMindBridgeImplUnitTest.cpp
@@ -6,6 +6,17 @@
 #include "mocks/ThreadSafeQueueInterfaceMock.h"
 #include <gmock/gmock.h>
 
+std::function<std::optional<CallbackArgs>()> validCallbackWithInstantReturn = []() -> std::optional<CallbackArgs> {
+    CallbackArgs returnArgs;
+    returnArgs[0] = FunctionCallArgumentDTO(1.0f);
+
+    return returnArgs;
+};
+
+std::function<std::optional<CallbackArgs>()> validCallbackWithoutInstantReturn = []() -> std::optional<CallbackArgs> {
+    return {};
+};
+
 class HiveMindBridgeImplUnitFixture : public testing::Test {
   protected:
     TCPServerInterfaceMock m_tcpServer;
@@ -15,33 +26,51 @@ class HiveMindBridgeImplUnitFixture : public testing::Test {
     ThreadSafeQueueInterfaceMock<MessageDTO> m_queue;
     MessageHandlerInterfaceMock m_messageHandler;
 
+    MessageHandlerResult validResultWithReturn;
+    MessageDTO dummyResponseMessage = MessageUtils::createResponseMessage(1,1,1,UserCallTargetDTO::UNKNOWN,GenericResponseStatusDTO::Ok,"");
+
     void SetUp() {
         m_hivemindBridge = new HiveMindBridgeImpl(m_tcpServer, m_serializer, m_deserializer, m_messageHandler, m_queue);
+
     }
 
     void TearDown() { delete m_hivemindBridge; }
 };
 
-TEST_F(HiveMindBridgeImplUnitFixture, spinReceiveValidMessage) {
+TEST_F(HiveMindBridgeImplUnitFixture, spinInstantaneousCallback_WithReturn) {
+    // Given
+    validResultWithReturn.setFuture(std::async(std::launch::async, validCallbackWithInstantReturn).share());
+    validResultWithReturn.setResponse(dummyResponseMessage);
+    std::this_thread::sleep_for(std::chrono::milliseconds(250)); // Just to make sure the callback ends before test
+
+    // When
     EXPECT_CALL(m_tcpServer, isClientConnected()).WillOnce(testing::Return(true));
     EXPECT_CALL(m_queue, empty()).WillOnce(testing::Return(false));
     EXPECT_CALL(m_queue, front());
+    EXPECT_CALL(m_messageHandler, handleMessage(testing::_)).WillOnce(testing::Return(validResultWithReturn));
     EXPECT_CALL(m_queue, pop());
-    EXPECT_CALL(m_serializer, serializeToStream(testing::_));
+    EXPECT_CALL(m_serializer, serializeToStream(testing::_)).Times(2); // ack + return
 
     m_hivemindBridge->spin();
+
+    // Then
 }
 
-TEST_F(HiveMindBridgeImplUnitFixture, spinReceiveNoMessage) {
+TEST_F(HiveMindBridgeImplUnitFixture, spinInstantaneousCallback_WithoutReturn) {
+    // Given
+    validResultWithReturn.setFuture(std::async(std::launch::async, validCallbackWithoutInstantReturn).share());
+    validResultWithReturn.setResponse(dummyResponseMessage);
+    std::this_thread::sleep_for(std::chrono::milliseconds(250)); // Just to make sure the callback ends before test
+
+    // When
     EXPECT_CALL(m_tcpServer, isClientConnected()).WillOnce(testing::Return(true));
-    EXPECT_CALL(m_deserializer, deserializeFromStream(testing::_)).WillOnce(testing::Return(false));
+    EXPECT_CALL(m_queue, empty()).WillOnce(testing::Return(false));
+    EXPECT_CALL(m_queue, front());
+    EXPECT_CALL(m_messageHandler, handleMessage(testing::_)).WillOnce(testing::Return(validResultWithReturn));
+    EXPECT_CALL(m_queue, pop());
+    EXPECT_CALL(m_serializer, serializeToStream(testing::_)).Times(1); // ack only
 
     m_hivemindBridge->spin();
-}
 
-//TEST_F(HiveMindBridgeImplUnitFixture, spinClientDisconnected) {
-//    EXPECT_CALL(m_tcpServer, isClientConnected()).WillOnce(testing::Return(false));
-//    EXPECT_CALL(m_tcpServer, listen());
-//
-//    m_hivemindBridge->spin();
-//}
+    // Then
+}

--- a/src/hive_mind_bridge/test/HiveMindBridgeImplUnitTest.cpp
+++ b/src/hive_mind_bridge/test/HiveMindBridgeImplUnitTest.cpp
@@ -1,3 +1,4 @@
+#include "hive_mind_bridge/Callback.h"
 #include "hive_mind_bridge/HiveMindBridgeImpl.h"
 #include "mocks/HiveMindHostDeserializerInterfaceMock.h"
 #include "mocks/HiveMindHostSerializerInterfaceMock.h"
@@ -6,16 +7,17 @@
 #include "mocks/ThreadSafeQueueInterfaceMock.h"
 #include <gmock/gmock.h>
 
-std::function<std::optional<CallbackArgs>()> validCallbackWithInstantReturn =
-    []() -> std::optional<CallbackArgs> {
+std::function<std::optional<CallbackReturn>()> validCallbackWithInstantReturn =
+    []() -> std::optional<CallbackReturn> {
     CallbackArgs returnArgs;
     returnArgs[0] = FunctionCallArgumentDTO(1.0f);
 
-    return returnArgs;
+    CallbackReturn cbReturn("instantReturn", returnArgs);
+    return cbReturn;
 };
 
-std::function<std::optional<CallbackArgs>()> validCallbackWithoutInstantReturn =
-    []() -> std::optional<CallbackArgs> { return {}; };
+std::function<std::optional<CallbackReturn>()> validCallbackWithoutInstantReturn =
+    []() -> std::optional<CallbackReturn> { return {}; };
 
 class HiveMindBridgeImplUnitFixture : public testing::Test {
   protected:
@@ -40,7 +42,7 @@ class HiveMindBridgeImplUnitFixture : public testing::Test {
 
 TEST_F(HiveMindBridgeImplUnitFixture, spinInstantaneousCallback_WithReturn) {
     // Given
-    validResultWithReturn.setFuture(
+    validResultWithReturn.setCallbackReturnContext(
         std::async(std::launch::async, validCallbackWithInstantReturn).share());
     validResultWithReturn.setResponse(dummyResponseMessage);
     std::this_thread::sleep_for(
@@ -62,7 +64,7 @@ TEST_F(HiveMindBridgeImplUnitFixture, spinInstantaneousCallback_WithReturn) {
 
 TEST_F(HiveMindBridgeImplUnitFixture, spinInstantaneousCallback_WithoutReturn) {
     // Given
-    validResultWithReturn.setFuture(
+    validResultWithReturn.setCallbackReturnContext(
         std::async(std::launch::async, validCallbackWithoutInstantReturn).share());
     validResultWithReturn.setResponse(dummyResponseMessage);
     std::this_thread::sleep_for(

--- a/src/hive_mind_bridge/test/HiveMindBridgeImplUnitTest.cpp
+++ b/src/hive_mind_bridge/test/HiveMindBridgeImplUnitTest.cpp
@@ -1,6 +1,7 @@
 #include "hive_mind_bridge/HiveMindBridgeImpl.h"
 #include "mocks/HiveMindHostDeserializerInterfaceMock.h"
 #include "mocks/HiveMindHostSerializerInterfaceMock.h"
+#include "mocks/MessageHandlerInterfaceMock.h"
 #include "mocks/TCPServerInterfaceMock.h"
 #include "mocks/ThreadSafeQueueInterfaceMock.h"
 #include <gmock/gmock.h>
@@ -12,9 +13,10 @@ class HiveMindBridgeImplUnitFixture : public testing::Test {
     HiveMindHostSerializerInterfaceMock m_serializer;
     HiveMindBridgeImpl* m_hivemindBridge;
     ThreadSafeQueueInterfaceMock<MessageDTO> m_queue;
+    MessageHandlerInterfaceMock m_messageHandler;
 
     void SetUp() {
-        m_hivemindBridge = new HiveMindBridgeImpl(m_tcpServer, m_serializer, m_deserializer, m_queue);
+        m_hivemindBridge = new HiveMindBridgeImpl(m_tcpServer, m_serializer, m_deserializer, m_messageHandler, m_queue);
     }
 
     void TearDown() { delete m_hivemindBridge; }

--- a/src/hive_mind_bridge/test/MessageHandlerUnitTest.cpp
+++ b/src/hive_mind_bridge/test/MessageHandlerUnitTest.cpp
@@ -14,19 +14,19 @@ class MessageHandlerFixture : public testing::Test {
     bool m_testFunctionCalled = false;
     int m_testValue1 = 0;
     int m_testValue2 = 12;
-    uint32_t m_testcompoundSourceId = 0;
-    uint32_t m_testCompoundDestinationId = 0;
-    UserCallTargetDTO m_testModuleDestinationId = UserCallTargetDTO::UNKNOWN;
-    uint32_t m_testExpectedResponseId = 0;
 
     // Declare some test callbacks
-    CallbackFunction m_testFunction = [&](CallbackArgs args, int argsLength) {
+    CallbackFunction m_testFunction = [&](CallbackArgs args, int argsLength) -> CallbackArgs {
         m_testFunctionCalled = true;
+
+        return {};
     };
 
-    CallbackFunction m_moveByTestCallback = [&](CallbackArgs args, int argsLength) {
+    CallbackFunction m_moveByTestCallback = [&](CallbackArgs args, int argsLength) -> CallbackArgs {
         m_testValue1 += std::get<int64_t>(args[0].getArgument());
         m_testValue2 -= std::get<float>(args[1].getArgument());
+
+        return {};
     };
     CallbackArgsManifest m_moveByTestCallbackManifest;
 

--- a/src/hive_mind_bridge/test/MessageHandlerUnitTest.cpp
+++ b/src/hive_mind_bridge/test/MessageHandlerUnitTest.cpp
@@ -1,5 +1,5 @@
+#include "hive_mind_bridge/Callback.h"
 #include "hive_mind_bridge/MessageHandler.h"
-
 #include <gmock/gmock.h>
 #include <hivemind-host/FunctionCallArgumentDTO.h>
 #include <hivemind-host/FunctionCallRequestDTO.h>
@@ -17,14 +17,14 @@ class MessageHandlerFixture : public testing::Test {
 
     // Declare some test callbacks
     CallbackFunction m_testFunction = [&](CallbackArgs args,
-                                          int argsLength) -> std::optional<CallbackArgs> {
+                                          int argsLength) -> std::optional<CallbackReturn> {
         m_testFunctionCalled = true;
 
         return {};
     };
 
     CallbackFunction m_moveByTestCallback = [&](CallbackArgs args,
-                                                int argsLength) -> std::optional<CallbackArgs> {
+                                                int argsLength) -> std::optional<CallbackReturn> {
         m_testValue1 += std::get<int64_t>(args[0].getArgument());
         m_testValue2 -= std::get<float>(args[1].getArgument());
 
@@ -144,7 +144,7 @@ TEST_F(MessageHandlerFixture, testHandleMessageVoidFunctionSuccess) {
     GenericResponseDTO genericResponse = functionCallResponse.getResponse();
     ASSERT_EQ(genericResponse.getStatus(), GenericResponseStatusDTO::Ok);
 
-    result.getFuture().wait();
+    result.getCallbackReturnContext().wait();
 
     ASSERT_TRUE(m_testFunctionCalled);
 }
@@ -167,7 +167,7 @@ TEST_F(MessageHandlerFixture, TestHandleMessageMoveByFunctionSuccess) {
     GenericResponseDTO genericResponse = functionCallResponse.getResponse();
     ASSERT_EQ(genericResponse.getStatus(), GenericResponseStatusDTO::Ok);
 
-    result.getFuture().wait();
+    result.getCallbackReturnContext().wait();
 
     ASSERT_EQ(m_testValue1, 1);
     ASSERT_EQ(m_testValue2, 7);

--- a/src/hive_mind_bridge/test/MessageHandlerUnitTest.cpp
+++ b/src/hive_mind_bridge/test/MessageHandlerUnitTest.cpp
@@ -125,7 +125,9 @@ TEST_F(MessageHandlerFixture, testGetCallbackFail) {
 
 TEST_F(MessageHandlerFixture, testHandleMessageVoidFunctionSuccess) {
     m_messageHandler.registerCallback("TestFunctionCallRequestDTO", m_testFunction);
-    MessageDTO responseMessage = m_messageHandler.handleMessage(*m_messageDto);
+    MessageHandlerResult result = m_messageHandler.handleMessage(*m_messageDto);
+    MessageDTO responseMessage = result.getResponse();
+
     ASSERT_EQ(responseMessage.getSourceId(), 2);
     ASSERT_EQ(responseMessage.getDestinationId(), 99);
 
@@ -139,12 +141,16 @@ TEST_F(MessageHandlerFixture, testHandleMessageVoidFunctionSuccess) {
         std::get<FunctionCallResponseDTO>(userCallResponse.getResponse());
     GenericResponseDTO genericResponse = functionCallResponse.getResponse();
     ASSERT_EQ(genericResponse.getStatus(), GenericResponseStatusDTO::Ok);
+
+    result.getReturnValues().wait();
 
     ASSERT_TRUE(m_testFunctionCalled);
 }
 
 TEST_F(MessageHandlerFixture, TestHandleMessageMoveByFunctionSuccess) {
-    MessageDTO responseMessage = m_messageHandler.handleMessage(*m_moveByMessageDto);
+    MessageHandlerResult result = m_messageHandler.handleMessage(*m_moveByMessageDto);
+    MessageDTO responseMessage = result.getResponse();
+
     ASSERT_EQ(responseMessage.getSourceId(), 2);
     ASSERT_EQ(responseMessage.getDestinationId(), 99);
 
@@ -158,13 +164,17 @@ TEST_F(MessageHandlerFixture, TestHandleMessageMoveByFunctionSuccess) {
         std::get<FunctionCallResponseDTO>(userCallResponse.getResponse());
     GenericResponseDTO genericResponse = functionCallResponse.getResponse();
     ASSERT_EQ(genericResponse.getStatus(), GenericResponseStatusDTO::Ok);
+
+    result.getReturnValues().wait();
 
     ASSERT_EQ(m_testValue1, 1);
     ASSERT_EQ(m_testValue2, 7);
 }
 
 TEST_F(MessageHandlerFixture, testHandleMessageFail) {
-    MessageDTO responseMessage = m_messageHandler.handleMessage(*m_nonExistingMessageDto);
+    MessageHandlerResult result = m_messageHandler.handleMessage(*m_nonExistingMessageDto);
+    MessageDTO responseMessage = result.getResponse();
+
     ASSERT_EQ(responseMessage.getSourceId(), 2);
     ASSERT_EQ(responseMessage.getDestinationId(), 99);
 
@@ -193,9 +203,10 @@ TEST_F(MessageHandlerFixture, handleFunctionListLengthRequest) {
     m_messageHandler.registerCallback("TestFunctionCallRequestDTO3", m_testFunction);
 
     // When
-    MessageDTO responseMessage = m_messageHandler.handleMessage(incomingMessage);
+    MessageHandlerResult result = m_messageHandler.handleMessage(incomingMessage);
 
     // Then
+    MessageDTO responseMessage = result.getResponse();
     ResponseDTO response = std::get<ResponseDTO>(responseMessage.getMessage());
     UserCallResponseDTO userCallResponse = std::get<UserCallResponseDTO>(response.getResponse());
     FunctionListLengthResponseDTO functionListLengthResponse =
@@ -213,9 +224,10 @@ TEST_F(MessageHandlerFixture, handleFunctionDescriptionRequest) {
     MessageDTO incomingMessage(0, 0, request);
 
     // When
-    MessageDTO responseMessage = m_messageHandler.handleMessage(incomingMessage);
+    MessageHandlerResult result = m_messageHandler.handleMessage(incomingMessage);
 
     // Then
+    MessageDTO responseMessage = result.getResponse();
     ResponseDTO response = std::get<ResponseDTO>(responseMessage.getMessage());
     UserCallResponseDTO userCallResponse = std::get<UserCallResponseDTO>(response.getResponse());
     FunctionDescriptionResponseDTO functionDescriptionResponse =
@@ -245,9 +257,10 @@ TEST_F(MessageHandlerFixture, handleFunctionDescriptionRequestVoid) {
     MessageDTO incomingMessage(0, 0, request);
 
     // When
-    MessageDTO responseMessage = m_messageHandler.handleMessage(incomingMessage);
+    MessageHandlerResult result = m_messageHandler.handleMessage(incomingMessage);
 
     // Then
+    MessageDTO responseMessage = result.getResponse();
     ResponseDTO response = std::get<ResponseDTO>(responseMessage.getMessage());
     UserCallResponseDTO userCallResponse = std::get<UserCallResponseDTO>(response.getResponse());
     FunctionDescriptionResponseDTO functionDescriptionResponse =
@@ -268,9 +281,10 @@ TEST_F(MessageHandlerFixture, handleFunctionDescriptionRequestOutOfBounds) {
     MessageDTO incomingMessage(0, 0, request);
 
     // When
-    MessageDTO responseMessage = m_messageHandler.handleMessage(incomingMessage);
+    MessageHandlerResult result = m_messageHandler.handleMessage(incomingMessage);
 
     // Then
+    MessageDTO responseMessage = result.getResponse();
     ResponseDTO response = std::get<ResponseDTO>(responseMessage.getMessage());
     UserCallResponseDTO userCallResponse = std::get<UserCallResponseDTO>(response.getResponse());
 

--- a/src/hive_mind_bridge/test/MessageHandlerUnitTest.cpp
+++ b/src/hive_mind_bridge/test/MessageHandlerUnitTest.cpp
@@ -16,13 +16,15 @@ class MessageHandlerFixture : public testing::Test {
     int m_testValue2 = 12;
 
     // Declare some test callbacks
-    CallbackFunction m_testFunction = [&](CallbackArgs args, int argsLength) -> CallbackArgs {
+    CallbackFunction m_testFunction = [&](CallbackArgs args,
+                                          int argsLength) -> std::optional<CallbackArgs> {
         m_testFunctionCalled = true;
 
         return {};
     };
 
-    CallbackFunction m_moveByTestCallback = [&](CallbackArgs args, int argsLength) -> CallbackArgs {
+    CallbackFunction m_moveByTestCallback = [&](CallbackArgs args,
+                                                int argsLength) -> std::optional<CallbackArgs> {
         m_testValue1 += std::get<int64_t>(args[0].getArgument());
         m_testValue2 -= std::get<float>(args[1].getArgument());
 

--- a/src/hive_mind_bridge/test/MessageHandlerUnitTest.cpp
+++ b/src/hive_mind_bridge/test/MessageHandlerUnitTest.cpp
@@ -142,7 +142,7 @@ TEST_F(MessageHandlerFixture, testHandleMessageVoidFunctionSuccess) {
     GenericResponseDTO genericResponse = functionCallResponse.getResponse();
     ASSERT_EQ(genericResponse.getStatus(), GenericResponseStatusDTO::Ok);
 
-    result.getReturnValues().wait();
+    result.getFuture().wait();
 
     ASSERT_TRUE(m_testFunctionCalled);
 }
@@ -165,7 +165,7 @@ TEST_F(MessageHandlerFixture, TestHandleMessageMoveByFunctionSuccess) {
     GenericResponseDTO genericResponse = functionCallResponse.getResponse();
     ASSERT_EQ(genericResponse.getStatus(), GenericResponseStatusDTO::Ok);
 
-    result.getReturnValues().wait();
+    result.getFuture().wait();
 
     ASSERT_EQ(m_testValue1, 1);
     ASSERT_EQ(m_testValue2, 7);

--- a/src/hive_mind_bridge/test/SocketToMoveByIntegrationTest.cpp
+++ b/src/hive_mind_bridge/test/SocketToMoveByIntegrationTest.cpp
@@ -89,6 +89,9 @@ int main(int argc, char** argv) {
                  "\tDetails: %s",
                  status, details.c_str());
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+//        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        break;
     }
+
+    std::this_thread::sleep_for(std::chrono::seconds(20));
 }

--- a/src/hive_mind_bridge/test/SocketToMoveByIntegrationTest.cpp
+++ b/src/hive_mind_bridge/test/SocketToMoveByIntegrationTest.cpp
@@ -1,3 +1,4 @@
+#include "hive_mind_bridge/MessageUtils.h"
 #include "ros/ros.h"
 #include <arpa/inet.h>
 #include <chrono>
@@ -68,30 +69,66 @@ int main(int argc, char** argv) {
     RequestDTO moveByRequestDTO(1, userCallRequest);
     MessageDTO moveByMessageDTO(1, 2, moveByRequestDTO);
 
-    // Send the message over TCP to the bridge
-    while (true) {
-        serializer.serializeToStream(moveByMessageDTO);
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    MessageDTO getRobotStatusMessage =
+        MessageUtils::createFunctionCallRequest(1, 2, 99, UserCallTargetDTO::HOST, "getStatus");
 
-        // Listen for a response
-        MessageDTO message;
-        deserializer.deserializeFromStream(message);
-        ResponseDTO response = std::get<ResponseDTO>(message.getMessage());
-        UserCallResponseDTO userCallResponse =
-            std::get<UserCallResponseDTO>(response.getResponse());
-        FunctionCallResponseDTO functionCallResponse =
-            std::get<FunctionCallResponseDTO>(userCallResponse.getResponse());
-        GenericResponseDTO genericResponse = functionCallResponse.getResponse();
-        GenericResponseStatusDTO status = genericResponse.getStatus();
-        std::string details = genericResponse.getDetails();
-        ROS_INFO("RESPONSE FROM HOST: \n"
-                 "\tResponse status: %d\n"
-                 "\tDetails: %s",
-                 status, details.c_str());
 
-//        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-        break;
-    }
+    // Send getStatus request
+    serializer.serializeToStream(getRobotStatusMessage);
 
-    std::this_thread::sleep_for(std::chrono::seconds(20));
+    // Listen for ack
+    MessageDTO statusResponseMessage;
+    deserializer.deserializeFromStream(statusResponseMessage);
+    ResponseDTO statusResponse = std::get<ResponseDTO>(statusResponseMessage.getMessage());
+    UserCallResponseDTO statusUserCallResponse =
+            std::get<UserCallResponseDTO>(statusResponse.getResponse());
+    FunctionCallResponseDTO statusFunctionCallResponse =
+            std::get<FunctionCallResponseDTO>(statusUserCallResponse.getResponse());
+    GenericResponseDTO statusGenericResponse = statusFunctionCallResponse.getResponse();
+    GenericResponseStatusDTO statusStatus = statusGenericResponse.getStatus();
+    std::string statusDetails = statusGenericResponse.getDetails();
+    ROS_INFO("RESPONSE FROM HOST (getStatus): \n"
+             "\tResponse status: %d\n"
+             "\tDetails: %s",
+             statusStatus, statusDetails.c_str());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+    // Lister for return
+    MessageDTO statusReturnMessage;
+    deserializer.deserializeFromStream(statusReturnMessage);
+    RequestDTO statusReturnRequest = std::get<RequestDTO>(statusReturnMessage.getMessage());
+    UserCallRequestDTO statusReturnUserCallRequest = std::get<UserCallRequestDTO>(statusReturnRequest.getRequest());
+    FunctionCallRequestDTO statusReturnFunctionCallRequest = std::get<FunctionCallRequestDTO>(statusReturnUserCallRequest.getRequest());
+    std::string statusReturnFunctionName = statusReturnFunctionCallRequest.getFunctionName();
+    std::array statusReturnFunctionArgs = statusReturnFunctionCallRequest.getArguments();
+    int64_t arg0 = std::get<int64_t>(statusReturnFunctionArgs[0].getArgument());
+
+    ROS_INFO("RESPONSE FROM HOST (%s): \n"
+             "\tPayload: %d",
+             statusReturnFunctionName.c_str(), arg0);
+
+    // Send moveBy request
+    serializer.serializeToStream(moveByMessageDTO);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+    // Listen for a response
+    MessageDTO message;
+    deserializer.deserializeFromStream(message);
+    ResponseDTO response = std::get<ResponseDTO>(message.getMessage());
+    UserCallResponseDTO userCallResponse =
+        std::get<UserCallResponseDTO>(response.getResponse());
+    FunctionCallResponseDTO functionCallResponse =
+        std::get<FunctionCallResponseDTO>(userCallResponse.getResponse());
+    GenericResponseDTO genericResponse = functionCallResponse.getResponse();
+    GenericResponseStatusDTO status = genericResponse.getStatus();
+    std::string details = genericResponse.getDetails();
+    ROS_INFO("RESPONSE FROM HOST (moveBy): \n"
+             "\tResponse status: %d\n"
+             "\tDetails: %s",
+             status, details.c_str());
+
+    // Listen for a return message
+    MessageDTO returnMessage;
+    deserializer.deserializeFromStream(returnMessage);
 }

--- a/src/hive_mind_bridge/test/SocketToMoveByIntegrationTest.cpp
+++ b/src/hive_mind_bridge/test/SocketToMoveByIntegrationTest.cpp
@@ -72,7 +72,6 @@ int main(int argc, char** argv) {
     MessageDTO getRobotStatusMessage =
         MessageUtils::createFunctionCallRequest(1, 2, 99, UserCallTargetDTO::HOST, "getStatus");
 
-
     // Send getStatus request
     serializer.serializeToStream(getRobotStatusMessage);
 
@@ -81,9 +80,9 @@ int main(int argc, char** argv) {
     deserializer.deserializeFromStream(statusResponseMessage);
     ResponseDTO statusResponse = std::get<ResponseDTO>(statusResponseMessage.getMessage());
     UserCallResponseDTO statusUserCallResponse =
-            std::get<UserCallResponseDTO>(statusResponse.getResponse());
+        std::get<UserCallResponseDTO>(statusResponse.getResponse());
     FunctionCallResponseDTO statusFunctionCallResponse =
-            std::get<FunctionCallResponseDTO>(statusUserCallResponse.getResponse());
+        std::get<FunctionCallResponseDTO>(statusUserCallResponse.getResponse());
     GenericResponseDTO statusGenericResponse = statusFunctionCallResponse.getResponse();
     GenericResponseStatusDTO statusStatus = statusGenericResponse.getStatus();
     std::string statusDetails = statusGenericResponse.getDetails();
@@ -98,8 +97,10 @@ int main(int argc, char** argv) {
     MessageDTO statusReturnMessage;
     deserializer.deserializeFromStream(statusReturnMessage);
     RequestDTO statusReturnRequest = std::get<RequestDTO>(statusReturnMessage.getMessage());
-    UserCallRequestDTO statusReturnUserCallRequest = std::get<UserCallRequestDTO>(statusReturnRequest.getRequest());
-    FunctionCallRequestDTO statusReturnFunctionCallRequest = std::get<FunctionCallRequestDTO>(statusReturnUserCallRequest.getRequest());
+    UserCallRequestDTO statusReturnUserCallRequest =
+        std::get<UserCallRequestDTO>(statusReturnRequest.getRequest());
+    FunctionCallRequestDTO statusReturnFunctionCallRequest =
+        std::get<FunctionCallRequestDTO>(statusReturnUserCallRequest.getRequest());
     std::string statusReturnFunctionName = statusReturnFunctionCallRequest.getFunctionName();
     std::array statusReturnFunctionArgs = statusReturnFunctionCallRequest.getArguments();
     int64_t arg0 = std::get<int64_t>(statusReturnFunctionArgs[0].getArgument());
@@ -116,8 +117,7 @@ int main(int argc, char** argv) {
     MessageDTO message;
     deserializer.deserializeFromStream(message);
     ResponseDTO response = std::get<ResponseDTO>(message.getMessage());
-    UserCallResponseDTO userCallResponse =
-        std::get<UserCallResponseDTO>(response.getResponse());
+    UserCallResponseDTO userCallResponse = std::get<UserCallResponseDTO>(response.getResponse());
     FunctionCallResponseDTO functionCallResponse =
         std::get<FunctionCallResponseDTO>(userCallResponse.getResponse());
     GenericResponseDTO genericResponse = functionCallResponse.getResponse();

--- a/src/hive_mind_bridge/test/mocks/MessageHandlerInterfaceMock.h
+++ b/src/hive_mind_bridge/test/mocks/MessageHandlerInterfaceMock.h
@@ -9,9 +9,11 @@ class MessageHandlerInterfaceMock : public IMessageHandler {
   public:
     ~MessageHandlerInterfaceMock() = default;
 
-    MOCK_METHOD(MessageDTO, handleMessage, (MessageDTO message), (override));
+    MOCK_METHOD(MessageHandlerResult, handleMessage, (MessageDTO message), (override));
 
     MOCK_METHOD(bool, registerCallback, (std::string name, CallbackFunction callback), (override));
+
+    MOCK_METHOD(bool, registerCallback, (std::string name, CallbackFunction callback, CallbackArgsManifest manifest), (override));
 
     MOCK_METHOD(std::optional<CallbackFunction>,
                 getCallback,

--- a/src/hive_mind_bridge/test/mocks/MessageHandlerInterfaceMock.h
+++ b/src/hive_mind_bridge/test/mocks/MessageHandlerInterfaceMock.h
@@ -13,7 +13,10 @@ class MessageHandlerInterfaceMock : public IMessageHandler {
 
     MOCK_METHOD(bool, registerCallback, (std::string name, CallbackFunction callback), (override));
 
-    MOCK_METHOD(bool, registerCallback, (std::string name, CallbackFunction callback, CallbackArgsManifest manifest), (override));
+    MOCK_METHOD(bool,
+                registerCallback,
+                (std::string name, CallbackFunction callback, CallbackArgsManifest manifest),
+                (override));
 
     MOCK_METHOD(std::optional<CallbackFunction>,
                 getCallback,

--- a/src/hive_mind_bridge/test/mocks/ThreadSafeQueueInterfaceMock.h
+++ b/src/hive_mind_bridge/test/mocks/ThreadSafeQueueInterfaceMock.h
@@ -1,0 +1,25 @@
+#ifndef HIVE_MIND_BRIDGE_THREADSAFEQUEUEINTERFACEMOCK_H
+#define HIVE_MIND_BRIDGE_THREADSAFEQUEUEINTERFACEMOCK_H
+
+//#include <gmock/gmock.h>
+#include "hive_mind_bridge/IThreadSafeQueue.h"
+
+template <class T>
+class ThreadSafeQueueInterfaceMock : public IThreadSafeQueue<T>{
+public:
+    ~ThreadSafeQueueInterfaceMock() = default;
+
+    MOCK_METHOD(void, push, (const T& item), (override));
+
+    MOCK_METHOD(void, pop, (), (override));
+
+    MOCK_METHOD(T, front, (), (override));
+
+    MOCK_METHOD(T, back, (), (override));
+
+    MOCK_METHOD(size_t, size, (), (override));
+
+    MOCK_METHOD(bool, empty, (), (override));
+};
+
+#endif //HIVE_MIND_BRIDGE_THREADSAFEQUEUEINTERFACEMOCK_H

--- a/src/hive_mind_bridge/test/mocks/ThreadSafeQueueInterfaceMock.h
+++ b/src/hive_mind_bridge/test/mocks/ThreadSafeQueueInterfaceMock.h
@@ -5,8 +5,8 @@
 #include "hive_mind_bridge/IThreadSafeQueue.h"
 
 template <class T>
-class ThreadSafeQueueInterfaceMock : public IThreadSafeQueue<T>{
-public:
+class ThreadSafeQueueInterfaceMock : public IThreadSafeQueue<T> {
+  public:
     ~ThreadSafeQueueInterfaceMock() = default;
 
     MOCK_METHOD(void, push, (const T& item), (override));
@@ -22,4 +22,4 @@ public:
     MOCK_METHOD(bool, empty, (), (override));
 };
 
-#endif //HIVE_MIND_BRIDGE_THREADSAFEQUEUEINTERFACEMOCK_H
+#endif // HIVE_MIND_BRIDGE_THREADSAFEQUEUEINTERFACEMOCK_H


### PR DESCRIPTION
# Callbacks are async
Callbacks are now run as async functions. They can therefore be blocking, without clogging up the reception of new messages over TCP.

# Callbacks can optionally return data
Callbacks can return some data. If a callback returns some data, the data will automatically be packaged in a new functionCallRequest whose name will be automatically derived from the name of the callback by appending the string "Return". For example : if someone calls `getStatus`, the returned message will be `getStatusReturn`. The returned values are passed as arguments of the Return message (hence the fact that a callback now returns a type `CallbackArgs`, which is the same type as the input arguments).

The user can choose not to return data from a callback, since the returned data is wrapped in a `std::optional`. If the user doesn't return data, no return message is sent over TCP.

# Reading data on TCP is threaded
Since the call to recv on TCP is blocking, I had to start a receive thread that pushes incoming messages on a ThreadSafeQueue.