### PR TITLE
fix script and bump bridge lib

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -40,6 +40,15 @@ sudo apt-get update && apt-get install -y \
 # Install cmake from pip for the latest release
 pip3 install cmake
 
+# Install HiveMindBridge
+cd contrib/HiveMindBridge && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    sudo make install && \
+    cd ../../.. && pwd
+
 # Install Buzz. The /tmp/buzz path can be changed.
 git clone https://github.com/MISTLab/Buzz.git /tmp/buzz && \
     cd /tmp/buzz && \
@@ -49,13 +58,5 @@ git clone https://github.com/MISTLab/Buzz.git /tmp/buzz && \
     make && \
     sudo make install && \
     sudo ldconfig
-
-# Install HiveMindBridge
-cd contrib/HiveMindBridge && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
-    make && \
-    sudo make install
 
 

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -46,8 +46,7 @@ cd contrib/HiveMindBridge && \
     cd build && \
     cmake .. && \
     make && \
-    sudo make install && \
-    cd ../../.. && pwd
+    sudo make install
 
 # Install Buzz. The /tmp/buzz path can be changed.
 git clone https://github.com/MISTLab/Buzz.git /tmp/buzz && \


### PR DESCRIPTION
There was a problem with the install script where it tried to cd into a directory that was elsewhere. Should be fine now.