### PR TITLE
Default orientation moveBy command

### DIFF
--- a/src/swarmus_ros_navigation/src/Navigation.cpp
+++ b/src/swarmus_ros_navigation/src/Navigation.cpp
@@ -1,6 +1,6 @@
 #include "Navigation.hpp"
-#include <math.h>
 #include <geometry_msgs/TransformStamped.h>
+#include <math.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 static const uint32_t QUEUE_SIZE{1000};

--- a/src/swarmus_turtlebot/src/Navigation.cpp
+++ b/src/swarmus_turtlebot/src/Navigation.cpp
@@ -1,6 +1,6 @@
 #include "swarmus_turtlebot/Navigation.hpp"
-#include <math.h>
 #include <geometry_msgs/TransformStamped.h>
+#include <math.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 static const uint32_t QUEUE_SIZE{1000};


### PR DESCRIPTION
By default, moveBy goal will be set to orientation if robot was to go to goal in a straight line